### PR TITLE
zkvm: spec clarification and expanded rationale

### DIFF
--- a/zkvm/spec/ZkVM.md
+++ b/zkvm/spec/ZkVM.md
@@ -260,7 +260,7 @@ Constraints only have an effect if added to the constraint system using the [`ve
 ### Value type
 
 A value is a [linear type](#linear-types) representing a pair of *quantity* and *flavor*.
-Both quantity and flavor are represented as [scalars](#scalar).
+Both quantity and flavor are represented as [variables](#variable-type).
 Quantity is guaranteed to be in a 64-bit range (`[0..2^64-1]`).
 
 Values are created with [`issue`](#issue) and destroyed with [`retire`](#retire).
@@ -1387,7 +1387,7 @@ _proof V2 var1_ **reblind** → _var1_
 1. Pops [variable](#variable-type) `var1`.
 2. Pops [point](#point) `V2`.
 3. Pops [data](#data-type) `proof`.
-4. Checks that `var1` is a [detached variable](#variable-type) with commitment `V1`.
+4. Checks that `var1` is a [detached variable](#variable-type) and reads its commitment `V1` from the [VM list of variable commitments](#vm-state).
 5. Replaces commitment `V1` with `V2` for this variable.
 6. Verifies the [reblinding proof](#reblinding-proof) for the commitments `V1`, `V2` and proof data `proof`, [deferring all point operations](#deferred-point-operations)).
 7. Pushes back the detached variable `var1`.

--- a/zkvm/spec/ZkVM.md
+++ b/zkvm/spec/ZkVM.md
@@ -1858,15 +1858,14 @@ TBD.
 
 ### Payment channel example
 
-TBD.
-
-Payment channel is specified as follows:
+Payment channel overview:
 
 1. Parties prepare a 2-of-2 signature predicate.
-2. Parties pre-sign a "Close Channel" transaction that transfers funds to an intermediate "Close" contract. Each party pre-signs this to the counter-party. When both parties have exchanged their presigned contracts, they sign a funding tx that locks funds from each party in such 2-of-2 predicate.
-3. From the perspective of each party A, a "Close" contract can be spent either after a relative timeout of N seconds ("contest period"),
-   or immediately by the counter-party B, if B shows a signed proof of channel update.
-4. TBD.
+2. Parties pre-sign a "Force Close" transaction that transfers funds to an intermediate "Close" contract. Each party pre-signs this to the counter-party. When both parties have exchanged their presigned contracts, they sign a funding tx that locks funds from each party in such 2-of-2 predicate.
+3. From the perspective of each party A, a "Close" contract can be spent either after a relative timeout of N seconds ("contest period"), or immediately by the counter-party B, if B shows a signed proof of channel update.
+4. At any time, the current (possibly timelocked) state of the funds in a channel can be unlocked with a mutual agreement from both parties by signing a final "Mutual Close" transaction.
+
+TBD: specifics.
 
 ### Payment routing example
 

--- a/zkvm/spec/ZkVM.md
+++ b/zkvm/spec/ZkVM.md
@@ -1860,6 +1860,14 @@ TBD.
 
 TBD.
 
+Payment channel is specified as follows:
+
+1. Parties prepare a 2-of-2 signature predicate.
+2. Parties pre-sign a "Close Channel" transaction that transfers funds to an intermediate "Close" contract. Each party pre-signs this to the counter-party. When both parties have exchanged their presigned contracts, they sign a funding tx that locks funds from each party in such 2-of-2 predicate.
+3. From the perspective of each party A, a "Close" contract can be spent either after a relative timeout of N seconds ("contest period"),
+   or immediately by the counter-party B, if B shows a signed proof of channel update.
+4. TBD.
+
 ### Payment routing example
 
 TBD.

--- a/zkvm/spec/ZkVM.md
+++ b/zkvm/spec/ZkVM.md
@@ -2005,10 +2005,16 @@ In ZkVM:
 * [Transaction ID](#transaction-id) is globally unique,
 * [UTXO ID](#utxo) is globally unique,
 * [Nonce](#nonce) is globally unique,
-* [Value](#value-type) is not unique,
-* [Contract](#contract-type) is not unique.
+* [Value](#value-type) is **not** unique,
+* [Contract](#contract-type) is **not** unique.
 
-**Rationale:**
+In contrast, in TxVM:
+
+* [Transaction ID](#transaction-id) is globally unique,
+* [UTXO ID](#utxo) is **not** unique,
+* [Nonce](#nonce) is globally unique,
+* [Value](#value-type) is globally unique,
+* [Contract](#contract-type) is globally unique.
 
 TxVM ensures transaction uniqueness this way:
 
@@ -2034,7 +2040,7 @@ Storing anchor inside a value turned out to be handy, but is not very ergonomic.
 
 Another potential issue: UTXOs are not guaranteed to be always unique. E.g. if a contract does not modify its value and other content, it can re-save itself to the same UTXO ID. It can even toggle between different states, returning to the previously spent ID. This can cause issues in some applications that forget that UTXO ID in special circumstances can be resurrected.
 
-In ZkVM:
+ZkVM ensures transaction uniqueness this way:
 
 * Values do not have anchors.
 * We still have `nonce` instruction with the same semantics
@@ -2043,7 +2049,7 @@ In ZkVM:
 * `claim/borrow` can produce an arbitrary value and its negative at any point
 * Each UTXO ID is defined as `Hash(contract, txid)`, that is contents of the contract are not unique, but the new UTXO ID is defined by transaction ID, not vice versa.
 * Transaction ID is a hash of the finalized log.
-* When VM finishes, it checks that the log contains either an _input_ or a _nonce_, setting the `uniqueness` flag.
+* When VM finishes, it checks that the log contains either an [input](#input-entry) or a [nonce](#nonce-entry), setting the `uniqueness` flag.
 * Outputs are encoded in the log as snapshots of contents. Blockchain state update hashes these with transaction ID when generating UTXO IDs.
 * Inputs are encoded in the log as their UTXO IDs, so the blockchain processor knows which ones to find and remove.
 

--- a/zkvm/spec/ZkVM.md
+++ b/zkvm/spec/ZkVM.md
@@ -69,9 +69,14 @@ ZkVM defines a procedural representation for blockchain transactions and the rul
 * [Discussion](#discussion)
     * [Relation to TxVM](#relation-to-txvm)
     * [Compatibility](#compatibility)
-
-
-
+    * [Static arguments](#static-arguments)
+    * [Should cloak and borrow take variables and not commitments?](#should-cloak-and-borrow-take-variables-and-not-commitments)
+    * [Why there is no `and` combinator in the predicate tree?](#why-there-is-no-and-combinator-in-the-predicate-tree)
+    * [Why we need Wide value and `borrow`?](#why-we-need-wide-value-and-borrow)
+    * [How to perform an inequality constraint?](#how-to-perform-an-inequality-constraint)
+    * [How to perform a logical `not`?](#how-to-perform-a-logical-not)
+    * [What ensures transaction uniqueness?](#what-ensures-transaction-uniqueness)
+    * [Open questions](#open-questions)
 
 
 
@@ -1935,7 +1940,7 @@ program structure can be determined right before the use.
 2. txbuilder can keep the secrets assigned to variable instances, so it may be more convenient than remembering preimages for commitments.
 
 
-### Why there is no AND combinator in predicate tree?
+### Why there is no `and` combinator in the predicate tree?
 
 The payload of a contract must be provided to the selected branch. If both predicates must be evaluated and both are programs, then which one takes the payload? To avoid ambiguity, AND can be implemented inside a program that can explicitly decide in which order and which parts of payload to process: maybe check some conditions and then delegate the whole payload to a predicate, or split the payload in two parts and apply different predicates to each part. There's [`contract`](#contract) instruction for that delegation.
 
@@ -2048,11 +2053,9 @@ The values are simply pedersen commitments (Q,A) (quantity, flavor), without any
 UTXO IDs are not known until the full transaction log is formed. This could be not a big deal, as we cannot really plan for the next transaction until this one is fully formed and published. Also, in a joint proof scenario, it’s even less reliable to plan the next payment until the MPC is completed, so requirement to wait till transaction ID is determined may not be a big deal.
 
 
+### Open questions
 
-
-## Open questions
-
-### Do we really need qty/flavor introspection ops?
+#### Do we really need qty/flavor introspection ops?
 
 We currently need them to reblind the received value, but we normally use `borrow` instead of receiving some value and then placing bounds on it.
 

--- a/zkvm/spec/ZkVM.md
+++ b/zkvm/spec/ZkVM.md
@@ -39,7 +39,7 @@ ZkVM defines a procedural representation for blockchain transactions and the rul
     * [Output structure](#output-structure)
     * [Constraint system](#constraint-system)
     * [Constraint system proof](#constraint-system-proof)
-    * [Transaction witness](#transaction-witness)
+    * [Transaction](#transaction)
     * [Transaction log](#transaction-log)
     * [Transaction ID](#transaction-id)
     * [Merkle binary tree](#merkle-binary-tree)
@@ -93,7 +93,7 @@ ZkVM is the entirely new design that inherits most important insights from the T
 
 ### Concepts
 
-A transaction is represented by a [transaction witness](#transaction-witness) that
+A transaction is represented by a [transaction](#transaction) object that
 contains a [program](#program) that runs in the context of a stack-based virtual machine.
 
 When the virtual machine executes a program, it creates and manipulates data of various types:
@@ -547,9 +547,9 @@ A proof of satisfiability of a [constraint system](#constraint-system) built dur
 The proof is provided to the VM at the beggining of execution and verified when the VM is [finished](#vm-execution).
 
 
-### Transaction witness
+### Transaction
 
-Transaction witness is a structure that contains all data and logic
+Transaction is a structure that contains all data and logic
 required to produce a unique [transaction ID](#transaction-id):
 
 * Version (uint64)
@@ -979,7 +979,7 @@ V == v·B + 0·B2
 
 The ZkVM state consists of the static attributes and the state machine attributes.
 
-1. [Transaction witness](#transaction-witness):
+1. [Transaction](#transaction):
     * `version`
     * `mintime` and `maxtime`
     * `program`
@@ -1001,12 +1001,12 @@ The ZkVM state consists of the static attributes and the state machine attribute
 
 The VM is initialized with the following state:
 
-1. A [transaction witness](#transaction-witness) as provided by the user.
-2. Extension flag set to `true` or `false` according to the [transaction versioning](#versioning) rules for the witness version.
+1. [Transaction](#transaction) as provided by the user.
+2. Extension flag set to `true` or `false` according to the [transaction versioning](#versioning) rules for the transaction version.
 3. Uniqueness flag is set to `false`.
 4. Data stack is empty.
 5. Program stack is empty.
-6. Current program set to the transaction witness program; with zero offset.
+6. Current program set to the transaction program; with zero offset.
 7. Transaction log is empty.
 8. Array of signature verification keys is empty.
 9. Array of deferred point operations is empty.


### PR DESCRIPTION
* Clarifies that Value's qty and flv are _variables_, not _scalars_.
* Clarifies the `reblind` instruction: `V1` commitment is read from the internals of the variable `var1`.
* Discussion of the inequality constraints (`<,≤,>,≥`).
* Discussion of the logical `not` constraint.
* Discussion of the txid / utxo uniqueness and comparison with TxVM.
* To avoid confusion with cryptographic "witness" data (secret quantities, blinding factors, private keys etc), "Tx Witness" is renamed to "Tx object". This also matches the current API as it's implemented.