### PR TITLE
zkvm/vm: add witness fields and assignments for cloak variables

### DIFF
--- a/zkvm/src/errors.rs
+++ b/zkvm/src/errors.rs
@@ -63,6 +63,14 @@ pub enum VMError {
     #[fail(display = "Item is not a key.")]
     TypeNotKey,
 
+    /// This error occurs when a prover is supposed to provide signed integer.
+    #[fail(display = "Item is not a signed integer.")]
+    TypeNotSignedInteger,
+
+    /// This error occurs when a prover has an inconsistent combination of witness data
+    #[fail(display = "Witness data is inconsistent.")]
+    InconsistentWitness,
+
     /// This error occurs when an instruction requires a value type.
     #[fail(display = "Item is not a value.")]
     TypeNotValue,

--- a/zkvm/src/ops.rs
+++ b/zkvm/src/ops.rs
@@ -4,7 +4,7 @@ use crate::encoding::Subslice;
 use crate::errors::VMError;
 use crate::types::Data;
 
-#[derive(Debug)]
+#[derive(Clone,Debug)]
 pub enum Instruction {
     Push(Data), // size of the string
     Drop,

--- a/zkvm/src/ops.rs
+++ b/zkvm/src/ops.rs
@@ -4,7 +4,7 @@ use crate::encoding::Subslice;
 use crate::errors::VMError;
 use crate::types::Data;
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub enum Instruction {
     Push(Data), // size of the string
     Drop,

--- a/zkvm/src/ops.rs
+++ b/zkvm/src/ops.rs
@@ -4,7 +4,7 @@ use crate::encoding::Subslice;
 use crate::errors::VMError;
 use crate::types::Data;
 
-#[derive(Clone,Debug)]
+#[derive(Clone, Debug)]
 pub enum Instruction {
     Push(Data), // size of the string
     Drop,

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -1,10 +1,10 @@
 //! Core ZkVM stack types: data, variables, values, contracts etc.
 
 use bulletproofs::{r1cs, PedersenGens};
-use byteorder::{ByteOrder, LittleEndian};
 use curve25519_dalek::ristretto::CompressedRistretto;
 use curve25519_dalek::scalar::Scalar;
 use merlin::Transcript;
+use spacesuit::SignedInteger;
 
 use crate::encoding::Subslice;
 use crate::errors::VMError;
@@ -29,19 +29,10 @@ pub enum PortableItem {
     Value(Value),
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum Data {
     Opaque(Vec<u8>),
     Witness(DataWitness),
-}
-
-impl Data {
-    pub fn to_bytes(self) -> Vec<u8> {
-        match self {
-            Data::Opaque(data) => data,
-            Data::Witness(_) => unimplemented!(),
-        }
-    }
 }
 
 #[derive(Debug)]
@@ -73,7 +64,7 @@ pub struct Variable {
 pub struct Expression {
     /// Terms of the expression
     pub(crate) terms: Vec<(r1cs::Variable, Scalar)>,
-    pub(crate) assignment: Option<u64>,
+    pub(crate) assignment: Option<SignedInteger>,
 }
 
 #[derive(Clone, Debug)]
@@ -85,7 +76,7 @@ pub enum Constraint {
     // this also allows us not to wrap this enum in a struct.
 }
 
-#[derive(Debug)]
+#[derive(Clone,Debug)]
 pub enum Predicate {
     Opaque(CompressedRistretto),
     Witness(Box<PredicateWitness>),
@@ -97,24 +88,24 @@ pub enum Commitment {
     Open(Box<CommitmentWitness>),
 }
 
-#[derive(Debug)]
+#[derive(Clone,Debug)]
 pub enum Input {
     Opaque(Vec<u8>),
-    Witness(Box<(Contract, UTXO)>),
+    Witness(Box<(FrozenContract, UTXO)>),
 }
 
 /// Prover's representation of the witness.
-#[derive(Debug)]
+#[derive(Clone,Debug)]
 pub enum DataWitness {
     Program(Vec<Instruction>),
     Predicate(Box<PredicateWitness>), // maybe having Predicate and one more indirection would be cleaner - lets see how it plays out
     Commitment(Box<CommitmentWitness>),
     Scalar(Box<Scalar>),
-    Input(Box<(Contract, UTXO)>),
+    Input(Box<(FrozenContract, UTXO)>),
 }
 
 /// Prover's representation of the predicate tree with all the secrets
-#[derive(Debug)]
+#[derive(Clone,Debug)]
 pub enum PredicateWitness {
     Key(Scalar),
     Program(Vec<Instruction>),
@@ -128,9 +119,32 @@ pub struct CommitmentWitness {
     pub blinding: Scalar,
 }
 
+/// Representation of a Contract inside an Input that can be cloned.
+#[derive(Clone,Debug)]
+pub struct FrozenContract {
+    pub(crate) payload: Vec<FrozenItem>,
+    pub(crate) predicate: Predicate,
+}
+
+/// Representation of a PortableItem inside an Input that can be cloned. 
+#[derive(Clone,Debug)]
+pub enum FrozenItem {
+    Data(Data),
+    Value(FrozenValue),
+}
+
+/// Representation of a Value inside an Input that can be cloned.
+/// Note: values do not necessarily have open commitments. Some can be reblinded,
+/// others can be passed-through to an output without going through `cloak` and the constraint system.
+#[derive(Clone, Debug)]
+pub struct FrozenValue {
+    pub(crate) qty: Commitment,
+    pub(crate) flv: Commitment,
+}
+
 #[derive(Copy,Clone,Debug)]
 pub enum ScalarKind {
-    Integer(u64),
+    Integer(SignedInteger),
     Scalar(Scalar),
 }
 
@@ -234,19 +248,18 @@ impl Item {
 }
 
 impl Data {
-    // len returns the length of the data for purposes of
-    // allocating output.
-    pub fn exact_output_size(&self) -> usize {
+    /// Returns the length of the underlying vector of bytes.
+    pub fn len(&self) -> usize {
         match self {
             Data::Opaque(data) => data.len(),
             Data::Witness(_) => unimplemented!(),
         }
     }
 
-    // TBD: make frozen types that are clonable
-    pub fn tbd_clone(&self) -> Result<Data, VMError> {
+    /// Converts the Data into a vector of bytes
+    pub fn to_bytes(self) -> Vec<u8> {
         match self {
-            Data::Opaque(data) => Ok(Data::Opaque(data.to_vec())),
+            Data::Opaque(data) => data,
             Data::Witness(_) => unimplemented!(),
         }
     }
@@ -294,7 +307,7 @@ impl Contract {
         let mut size = 32 + 4;
         for item in self.payload.iter() {
             match item {
-                PortableItem::Data(d) => size += 1 + 4 + d.exact_output_size(),
+                PortableItem::Data(d) => size += 1 + 4 + d.len(),
                 PortableItem::Value(_) => size += 1 + 64,
             }
         }

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -51,7 +51,7 @@ pub struct Value {
 pub struct WideValue {
     pub(crate) r1cs_qty: r1cs::Variable,
     pub(crate) r1cs_flv: r1cs::Variable,
-    pub(crate) witness: Option<(Scalar, Scalar)>,
+    pub(crate) witness: Option<(SignedInteger, Scalar)>,
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -76,7 +76,7 @@ pub enum Constraint {
     // this also allows us not to wrap this enum in a struct.
 }
 
-#[derive(Clone,Debug)]
+#[derive(Clone, Debug)]
 pub enum Predicate {
     Opaque(CompressedRistretto),
     Witness(Box<PredicateWitness>),
@@ -88,14 +88,14 @@ pub enum Commitment {
     Open(Box<CommitmentWitness>),
 }
 
-#[derive(Clone,Debug)]
+#[derive(Clone, Debug)]
 pub enum Input {
     Opaque(Vec<u8>),
     Witness(Box<(FrozenContract, UTXO)>),
 }
 
 /// Prover's representation of the witness.
-#[derive(Clone,Debug)]
+#[derive(Clone, Debug)]
 pub enum DataWitness {
     Program(Vec<Instruction>),
     Predicate(Box<PredicateWitness>), // maybe having Predicate and one more indirection would be cleaner - lets see how it plays out
@@ -105,7 +105,7 @@ pub enum DataWitness {
 }
 
 /// Prover's representation of the predicate tree with all the secrets
-#[derive(Clone,Debug)]
+#[derive(Clone, Debug)]
 pub enum PredicateWitness {
     Key(Scalar),
     Program(Vec<Instruction>),
@@ -120,14 +120,14 @@ pub struct CommitmentWitness {
 }
 
 /// Representation of a Contract inside an Input that can be cloned.
-#[derive(Clone,Debug)]
+#[derive(Clone, Debug)]
 pub struct FrozenContract {
     pub(crate) payload: Vec<FrozenItem>,
     pub(crate) predicate: Predicate,
 }
 
-/// Representation of a PortableItem inside an Input that can be cloned. 
-#[derive(Clone,Debug)]
+/// Representation of a PortableItem inside an Input that can be cloned.
+#[derive(Clone, Debug)]
 pub enum FrozenItem {
     Data(Data),
     Value(FrozenValue),
@@ -142,7 +142,7 @@ pub struct FrozenValue {
     pub(crate) flv: Commitment,
 }
 
-#[derive(Copy,Clone,Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum ScalarKind {
     Integer(SignedInteger),
     Scalar(Scalar),
@@ -168,7 +168,7 @@ impl Into<Scalar> for ScalarKind {
     fn into(self) -> Scalar {
         match self {
             ScalarKind::Integer(i) => i.into(),
-            ScalarKind::Scalar(s) => s
+            ScalarKind::Scalar(s) => s,
         }
     }
 }

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -1,5 +1,6 @@
 use bulletproofs::r1cs;
 use bulletproofs::r1cs::R1CSProof;
+use byteorder::{ByteOrder, LittleEndian};
 use curve25519_dalek::ristretto::CompressedRistretto;
 use curve25519_dalek::scalar::Scalar;
 use spacesuit;
@@ -265,7 +266,7 @@ where
         }
         let item_idx = self.stack.len() - i - 1;
         let item = match &self.stack[item_idx] {
-            Item::Data(x) => Item::Data(x.clone()),
+            Item::Data(x) => Item::Data(x.tbd_clone()?),
             Item::Variable(x) => Item::Variable(x.clone()),
             Item::Expression(x) => Item::Expression(x.clone()),
             Item::Constraint(x) => Item::Constraint(x.clone()),
@@ -323,7 +324,7 @@ where
 
         let value = Value { qty, flv };
 
-        let qty_expr = self.variable_to_expression(qty);
+        let qty_expr = self.variable_to_expression(qty)?;
         self.add_range_proof(64, qty_expr)?;
 
         self.txlog.push(Entry::Issue(qty_point, flv_point));
@@ -515,11 +516,14 @@ where
     }
 
     fn value_to_cloak_value(&mut self, value: &Value) -> spacesuit::AllocatedValue {
+        let assignment = match (self.variable_assignment(value.qty), self.variable_assignment(value.flv)) {
+            (Some(ScalarKind::Integer(q)), Some(ScalarKind::Scalar(f))) => Some(spacesuit::Value { q, f }),
+            (_, _) => None
+        };
         spacesuit::AllocatedValue {
             q: self.attach_variable(value.qty).1,
             f: self.attach_variable(value.flv).1,
-            // TBD: maintain assignments inside Value types in order to use ZkVM to compute the R1CS proof
-            assignment: None,
+            assignment,
         }
     }
 
@@ -527,8 +531,13 @@ where
         spacesuit::AllocatedValue {
             q: walue.r1cs_qty,
             f: walue.r1cs_flv,
-            // TBD: maintain assignments inside WideValue types in order to use ZkVM to compute the R1CS proof
-            assignment: None,
+            assignment: match walue.witness {
+                None => None,
+                Some(w) => Some(spacesuit::Value {
+                    q: scalar_to_u64(w.0),
+                    f: w.1,
+                }),
+            },
         }
     }
 
@@ -537,18 +546,37 @@ where
             Item::Value(value) => Ok(WideValue {
                 r1cs_qty: self.attach_variable(value.qty).1,
                 r1cs_flv: self.attach_variable(value.flv).1,
-                // TBD: add witness for Value types where it exists.
-                witness: None,
+                witness: match (self.variable_assignment(value.qty), self.variable_assignment(value.flv)) {
+                    (Some(ScalarKind::Scalar(q)), Some(ScalarKind::Scalar(f))) => Some((q, f)),
+                    (None, None) => None,
+                    (_, _) => return Err(VMError::FormatError),
+                },
             }),
             Item::WideValue(w) => Ok(w),
             _ => Err(VMError::TypeNotWideValue),
         }
     }
 
-    fn variable_to_expression(&mut self, var: Variable) -> Expression {
+    fn variable_to_expression(&mut self, var: Variable) -> Result<Expression, VMError> {
         let (_, r1cs_var) = self.attach_variable(var);
-        Expression {
+        let expr = Expression {
             terms: vec![(r1cs_var, Scalar::one())],
+            assignment: match self.variable_assignment(var) {
+                None => None,
+                Some(v) => match v {
+                    ScalarKind::Integer(i) => Some(i),
+                    ScalarKind::Scalar(_) => return Err(VMError::FormatError),
+                }
+            },
+        };
+        Ok(expr)
+    }
+
+    fn variable_assignment(&mut self, var: Variable) -> Option<ScalarKind> {
+        let v_com = &self.variable_commitments[var.index];
+        match &v_com.commitment {
+            Commitment::Closed(_) => None,
+            Commitment::Open(w) => Some(w.value),
         }
     }
 
@@ -644,10 +672,14 @@ where
         spacesuit::range_proof(
             self.delegate.cs(),
             r1cs::LinearCombination::from_iter(expr.terms),
-            // TBD: maintain the assignment for the expression and provide it here
-            None,
+            expr.assignment,
             bitrange,
         )
         .map_err(|_| VMError::R1CSInconsistency)
     }
+}
+
+// Helper methods
+fn scalar_to_u64(scalar: Scalar) -> u64 {
+    LittleEndian::read_u64(&scalar.to_bytes())
 }

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -686,8 +686,3 @@ where
         .map_err(|_| VMError::R1CSInconsistency)
     }
 }
-
-// Helper functions
-fn scalar_to_u64(scalar: Scalar) -> u64 {
-    LittleEndian::read_u64(&scalar.to_bytes())
-}

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -539,7 +539,7 @@ where
             assignment: match walue.witness {
                 None => None,
                 Some(w) => Some(spacesuit::Value {
-                    q: scalar_to_u64(w.0).into(),
+                    q: w.0,
                     f: w.1,
                 }),
             },
@@ -555,7 +555,7 @@ where
                     self.variable_assignment(value.qty),
                     self.variable_assignment(value.flv),
                 ) {
-                    (Some(ScalarKind::Scalar(q)), Some(ScalarKind::Scalar(f))) => Some((q, f)),
+                    (Some(ScalarKind::Integer(q)), Some(ScalarKind::Scalar(f))) => Some((q, f)),
                     (None, None) => None,
                     (_, _) => return Err(VMError::FormatError),
                 },

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -516,9 +516,14 @@ where
     }
 
     fn value_to_cloak_value(&mut self, value: &Value) -> spacesuit::AllocatedValue {
-        let assignment = match (self.variable_assignment(value.qty), self.variable_assignment(value.flv)) {
-            (Some(ScalarKind::Integer(q)), Some(ScalarKind::Scalar(f))) => Some(spacesuit::Value { q, f }),
-            (_, _) => None
+        let assignment = match (
+            self.variable_assignment(value.qty),
+            self.variable_assignment(value.flv),
+        ) {
+            (Some(ScalarKind::Integer(q)), Some(ScalarKind::Scalar(f))) => {
+                Some(spacesuit::Value { q, f })
+            }
+            (_, _) => None,
         };
         spacesuit::AllocatedValue {
             q: self.attach_variable(value.qty).1,
@@ -533,12 +538,10 @@ where
             f: walue.r1cs_flv,
             assignment: match walue.witness {
                 None => None,
-                Some(w) =>{
-                    Some(spacesuit::Value {
-                        q: scalar_to_u64(w.0).into(),
-                        f: w.1,
-                    })
-                },
+                Some(w) => Some(spacesuit::Value {
+                    q: scalar_to_u64(w.0).into(),
+                    f: w.1,
+                }),
             },
         }
     }
@@ -548,7 +551,10 @@ where
             Item::Value(value) => Ok(WideValue {
                 r1cs_qty: self.attach_variable(value.qty).1,
                 r1cs_flv: self.attach_variable(value.flv).1,
-                witness: match (self.variable_assignment(value.qty), self.variable_assignment(value.flv)) {
+                witness: match (
+                    self.variable_assignment(value.qty),
+                    self.variable_assignment(value.flv),
+                ) {
                     (Some(ScalarKind::Scalar(q)), Some(ScalarKind::Scalar(f))) => Some((q, f)),
                     (None, None) => None,
                     (_, _) => return Err(VMError::FormatError),
@@ -568,7 +574,7 @@ where
                 Some(v) => match v {
                     ScalarKind::Integer(i) => Some(i),
                     ScalarKind::Scalar(_) => return Err(VMError::FormatError),
-                }
+                },
             },
         };
         Ok(expr)

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -266,7 +266,7 @@ where
         }
         let item_idx = self.stack.len() - i - 1;
         let item = match &self.stack[item_idx] {
-            Item::Data(x) => Item::Data(x.tbd_clone()?),
+            Item::Data(x) => Item::Data(x.clone()),
             Item::Variable(x) => Item::Variable(x.clone()),
             Item::Expression(x) => Item::Expression(x.clone()),
             Item::Constraint(x) => Item::Constraint(x.clone()),
@@ -533,10 +533,12 @@ where
             f: walue.r1cs_flv,
             assignment: match walue.witness {
                 None => None,
-                Some(w) => Some(spacesuit::Value {
-                    q: scalar_to_u64(w.0),
-                    f: w.1,
-                }),
+                Some(w) =>{
+                    Some(spacesuit::Value {
+                        q: scalar_to_u64(w.0).into(),
+                        f: w.1,
+                    })
+                },
             },
         }
     }
@@ -679,7 +681,7 @@ where
     }
 }
 
-// Helper methods
+// Helper functions
 fn scalar_to_u64(scalar: Scalar) -> u64 {
     LittleEndian::read_u64(&scalar.to_bytes())
 }

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -538,10 +538,7 @@ where
             f: walue.r1cs_flv,
             assignment: match walue.witness {
                 None => None,
-                Some(w) => Some(spacesuit::Value {
-                    q: w.0,
-                    f: w.1,
-                }),
+                Some(w) => Some(spacesuit::Value { q: w.0, f: w.1 }),
             },
         }
     }


### PR DESCRIPTION
Uses the `SignedInteger` type from spacesuit and fills in the witness and assignment fields for cloak variables.