### PR TITLE
zkvm/prover: implement traits and build_tx for prover

### DIFF
--- a/zkvm/src/ops.rs
+++ b/zkvm/src/ops.rs
@@ -1,3 +1,4 @@
+use core::borrow::Borrow;
 use core::mem;
 
 use crate::encoding::Subslice;
@@ -194,5 +195,15 @@ impl Instruction {
     /// to the program.
     pub fn encode(&self, program: &mut Vec<u8>) {
         unimplemented!()
+    }
+
+    pub fn encode_program<I>(iterator: I, program: &mut Vec<u8>)
+    where
+        I: IntoIterator,
+        I::Item: Borrow<Self>,
+    {
+        for i in iterator.into_iter() {
+            i.borrow().encode(program);
+        }
     }
 }

--- a/zkvm/src/ops.rs
+++ b/zkvm/src/ops.rs
@@ -190,8 +190,9 @@ impl Instruction {
         }
     }
 
-    /// Returns the bytecode representation of an Instruction.
-    pub fn encode(&self) -> Vec<u8> {
+    /// Appends the bytecode representation of an Instruction
+    /// to the program.
+    pub fn encode(&self, program: &mut Vec<u8>) {
         unimplemented!()
     }
 }

--- a/zkvm/src/ops.rs
+++ b/zkvm/src/ops.rs
@@ -107,11 +107,13 @@ impl Opcode {
 }
 
 impl Instruction {
-    /// Returns a parsed instruction with a size that it occupies in the program string.
-    /// E.g. a push instruction with 5-byte string occupies 1+4+5=10 bytes
-    /// (4 for the LE32 length prefix).
+    /// Returns a parsed instruction from a subslice of the program string, modifying
+    /// the subslice according to the bytes the instruction occupies
+    /// E.g. a push instruction with 5-byte string occupies 1+4+5=10 bytes,
+    /// (4 for the LE32 length prefix), advancing the program subslice by 10 bytes.
     ///
-    /// Return `VMError::FormatError` if there is not enough bytes to parse an instruction.
+    /// Return `VMError::FormatError` if there are not enough bytes to parse an
+    /// instruction.
     pub fn parse(program: &mut Subslice) -> Result<Self, VMError> {
         let byte = program.read_u8()?;
 
@@ -186,5 +188,10 @@ impl Instruction {
             Opcode::Right => Ok(Instruction::Right),
             Opcode::Delegate => Ok(Instruction::Delegate),
         }
+    }
+
+    /// Returns the bytecode representation of an Instruction.
+    pub fn encode(&self) -> Vec<u8> {
+        unimplemented!()
     }
 }

--- a/zkvm/src/prover.rs
+++ b/zkvm/src/prover.rs
@@ -95,7 +95,7 @@ impl<'a, 'b> Prover<'a, 'b> {
             version,
             mintime,
             maxtime,
-            ProverRun::root(program),
+            ProverRun::from_txprogram(program),
             &mut prover,
         );
 
@@ -121,13 +121,13 @@ impl<'a, 'b> Prover<'a, 'b> {
 }
 
 impl ProverRun {
-    fn root(program: Vec<Instruction>) -> Self {
+    fn from_txprogram(program: Vec<Instruction>) -> Self {
         ProverRun {
             program: program.into(),
             root: true,
         }
     }
-    fn subprogram(program: Vec<Instruction>) -> Self {
+    fn from_subprogram(program: Vec<Instruction>) -> Self {
         ProverRun {
             program: program.into(),
             root: false,

--- a/zkvm/src/txlog.rs
+++ b/zkvm/src/txlog.rs
@@ -3,6 +3,8 @@ use merlin::Transcript;
 
 use crate::transcript::TranscriptProtocol;
 
+pub type TxLog = Vec<Entry>;
+
 /// Entry in a transaction log
 #[derive(Clone, PartialEq, Debug)]
 pub enum Entry {

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -158,6 +158,13 @@ impl Commitment {
             Commitment::Open(w) => w.to_point(),
         }
     }
+
+    pub fn ensure_closed(&self) -> Result<CompressedRistretto, VMError> {
+        match self {
+            Commitment::Open(_) => Err(VMError::DataNotOpaque),
+            Commitment::Closed(x) => Ok(*x),
+        }
+    }
 }
 
 impl CommitmentWitness {

--- a/zkvm/src/verifier.rs
+++ b/zkvm/src/verifier.rs
@@ -26,10 +26,16 @@ pub struct RunVerifier {
 impl<'a, 'b> Delegate<r1cs::Verifier<'a, 'b>> for Verifier<'a, 'b> {
     type RunType = RunVerifier;
 
-    fn commit_variable(&mut self, com: &Commitment) -> (CompressedRistretto, r1cs::Variable) {
-        let point = com.to_point();
-        let var = self.cs.commit(point);
-        (point, var)
+    fn commit_variable(
+        &mut self,
+        com: &Commitment,
+    ) -> Result<(CompressedRistretto, r1cs::Variable), VMError> {
+        let point = match com {
+            Commitment::Closed(p) => p,
+            Commitment::Open(_) => return Err(VMError::DataNotOpaque),
+        };
+        let var = self.cs.commit(*point);
+        Ok((*point, var))
     }
 
     fn verify_point_op<F>(&mut self, point_op_fn: F)

--- a/zkvm/src/verifier.rs
+++ b/zkvm/src/verifier.rs
@@ -18,13 +18,13 @@ pub struct Verifier<'a, 'b> {
     cs: r1cs::Verifier<'a, 'b>,
 }
 
-pub struct RunVerifier {
+pub struct VerifierRun {
     program: Vec<u8>,
     offset: usize,
 }
 
 impl<'a, 'b> Delegate<r1cs::Verifier<'a, 'b>> for Verifier<'a, 'b> {
-    type RunType = RunVerifier;
+    type RunType = VerifierRun;
 
     fn commit_variable(
         &mut self,
@@ -73,7 +73,7 @@ impl<'a, 'b> Verifier<'a, 'b> {
             tx.version,
             tx.mintime,
             tx.maxtime,
-            RunVerifier::new(tx.program),
+            VerifierRun::new(tx.program),
             &mut verifier,
         );
 
@@ -106,13 +106,13 @@ impl<'a, 'b> Verifier<'a, 'b> {
     }
 }
 
-impl RunVerifier {
+impl VerifierRun {
     fn new(program: Vec<u8>) -> Self {
-        RunVerifier { program, offset: 0 }
+        VerifierRun { program, offset: 0 }
     }
 }
 
-impl RunTrait for RunVerifier {
+impl RunTrait for VerifierRun {
     fn next_instruction(&mut self) -> Result<Option<Instruction>, VMError> {
         let mut program = Subslice::new_with_range(&self.program, self.offset..self.program.len())?;
 

--- a/zkvm/src/verifier.rs
+++ b/zkvm/src/verifier.rs
@@ -30,12 +30,9 @@ impl<'a, 'b> Delegate<r1cs::Verifier<'a, 'b>> for Verifier<'a, 'b> {
         &mut self,
         com: &Commitment,
     ) -> Result<(CompressedRistretto, r1cs::Variable), VMError> {
-        let point = match com {
-            Commitment::Closed(p) => p,
-            Commitment::Open(_) => return Err(VMError::DataNotOpaque),
-        };
-        let var = self.cs.commit(*point);
-        Ok((*point, var))
+        let point = com.ensure_closed()?;
+        let var = self.cs.commit(point);
+        Ok((point, var))
     }
 
     fn verify_point_op<F>(&mut self, point_op_fn: F) -> Result<(), VMError>

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -13,7 +13,7 @@ use crate::errors::VMError;
 use crate::ops::Instruction;
 use crate::point_ops::PointOp;
 use crate::signature::*;
-use crate::txlog::{Entry, TxID, UTXO};
+use crate::txlog::{Entry, TxID, TxLog, UTXO};
 use crate::types::*;
 
 /// Current tx version determines which extension opcodes are treated as noops (see VM.extension flag).
@@ -61,7 +61,7 @@ pub struct VerifiedTx {
     pub id: TxID,
 
     // List of inputs, outputs and nonces to be inserted/deleted in the blockchain state.
-    pub log: Vec<Entry>,
+    pub log: TxLog,
 }
 
 pub struct VM<'d, CS, D>
@@ -87,7 +87,7 @@ where
 
     current_run: D::RunType,
     run_stack: Vec<D::RunType>,
-    txlog: Vec<Entry>,
+    txlog: TxLog,
     variable_commitments: Vec<VariableCommitment>,
 }
 
@@ -162,7 +162,7 @@ where
     }
 
     /// Runs through the entire program and nested programs until completion.
-    pub fn run(mut self) -> Result<(TxID, Vec<Entry>), VMError> {
+    pub fn run(mut self) -> Result<(TxID, TxLog), VMError> {
         loop {
             if !self.step()? {
                 break;


### PR DESCRIPTION
Implements the `Delegate` and `RunTrait` traits needed by the VM for the prover. Also implements the `build_tx` function, minus the code to actually encode a prover's `Instruction` into tx bytecode for the verifier.