### PR TITLE
zkvm/prover: serialize instructions to bytecode

### DIFF
--- a/zkvm/src/encoding.rs
+++ b/zkvm/src/encoding.rs
@@ -124,6 +124,13 @@ pub fn write_u32<'a>(x: u32, target: &mut Vec<u8>) {
     target.extend_from_slice(&buf);
 }
 
+// Writes a LE64-encoded integer
+pub fn write_u64<'a>(x: u64, target: &mut Vec<u8>) {
+    let mut buf = [0u8; 8];
+    LittleEndian::write_u64(&mut buf, x);
+    target.extend_from_slice(&buf);
+}
+
 /// Reads a 32-byte array and returns the subsequent slice
 pub fn write_bytes(x: &[u8], target: &mut Vec<u8>) {
     target.extend_from_slice(&x);

--- a/zkvm/src/encoding.rs
+++ b/zkvm/src/encoding.rs
@@ -124,13 +124,6 @@ pub fn write_u32<'a>(x: u32, target: &mut Vec<u8>) {
     target.extend_from_slice(&buf);
 }
 
-// Writes a LE64-encoded integer
-pub fn write_u64<'a>(x: u64, target: &mut Vec<u8>) {
-    let mut buf = [0u8; 8];
-    LittleEndian::write_u64(&mut buf, x);
-    target.extend_from_slice(&buf);
-}
-
 /// Reads a 32-byte array and returns the subsequent slice
 pub fn write_bytes(x: &[u8], target: &mut Vec<u8>) {
     target.extend_from_slice(&x);

--- a/zkvm/src/ops.rs
+++ b/zkvm/src/ops.rs
@@ -1,6 +1,7 @@
 use core::borrow::Borrow;
 use core::mem;
 
+use crate::encoding;
 use crate::encoding::Subslice;
 use crate::errors::VMError;
 use crate::types::Data;
@@ -194,7 +195,69 @@ impl Instruction {
     /// Appends the bytecode representation of an Instruction
     /// to the program.
     pub fn encode(&self, program: &mut Vec<u8>) {
-        unimplemented!()
+        match self {
+            Instruction::Push(data) => {
+                program.push(Opcode::Push.to_u8());
+                data.encode(program);
+            }
+            Instruction::Drop => program.push(Opcode::Drop.to_u8()),
+            Instruction::Dup(idx) => {
+                program.push(Opcode::Dup.to_u8());
+                encoding::write_u32(*idx as u32, program);
+            }
+            Instruction::Roll(idx) => {
+                program.push(Opcode::Roll.to_u8());
+                encoding::write_u32(*idx as u32, program);
+            }
+            Instruction::Const => program.push(Opcode::Const.to_u8()),
+            Instruction::Var => program.push(Opcode::Var.to_u8()),
+            Instruction::Alloc => program.push(Opcode::Alloc.to_u8()),
+            Instruction::Mintime => program.push(Opcode::Mintime.to_u8()),
+            Instruction::Maxtime => program.push(Opcode::Maxtime.to_u8()),
+            Instruction::Neg => program.push(Opcode::Neg.to_u8()),
+            Instruction::Add => program.push(Opcode::Add.to_u8()),
+            Instruction::Mul => program.push(Opcode::Mul.to_u8()),
+            Instruction::Eq => program.push(Opcode::Eq.to_u8()),
+            Instruction::Range(bit_width) => {
+                program.push(Opcode::Range.to_u8());
+                program.push(*bit_width);
+            }
+            Instruction::And => program.push(Opcode::And.to_u8()),
+            Instruction::Or => program.push(Opcode::Or.to_u8()),
+            Instruction::Verify => program.push(Opcode::Verify.to_u8()),
+            Instruction::Blind => program.push(Opcode::Blind.to_u8()),
+            Instruction::Reblind => program.push(Opcode::Reblind.to_u8()),
+            Instruction::Unblind => program.push(Opcode::Unblind.to_u8()),
+            Instruction::Issue => program.push(Opcode::Issue.to_u8()),
+            Instruction::Borrow => program.push(Opcode::Borrow.to_u8()),
+            Instruction::Retire => program.push(Opcode::Retire.to_u8()),
+            Instruction::Qty => program.push(Opcode::Qty.to_u8()),
+            Instruction::Flavor => program.push(Opcode::Flavor.to_u8()),
+            Instruction::Cloak(m, n) => {
+                program.push(Opcode::Cloak.to_u8());
+                encoding::write_u32(*m as u32, program);
+                encoding::write_u32(*n as u32, program);
+            }
+            Instruction::Import => program.push(Opcode::Import.to_u8()),
+            Instruction::Export => program.push(Opcode::Export.to_u8()),
+            Instruction::Input => program.push(Opcode::Input.to_u8()),
+            Instruction::Output(k) => {
+                program.push(Opcode::Output.to_u8());
+                encoding::write_u32(*k as u32, program);
+            }
+            Instruction::Contract(k) => {
+                program.push(Opcode::Contract.to_u8());
+                encoding::write_u32(*k as u32, program);
+            }
+            Instruction::Nonce => program.push(Opcode::Nonce.to_u8()),
+            Instruction::Log => program.push(Opcode::Log.to_u8()),
+            Instruction::Signtx => program.push(Opcode::Signtx.to_u8()),
+            Instruction::Call => program.push(Opcode::Call.to_u8()),
+            Instruction::Left => program.push(Opcode::Left.to_u8()),
+            Instruction::Right => program.push(Opcode::Right.to_u8()),
+            Instruction::Delegate => program.push(Opcode::Delegate.to_u8()),
+            Instruction::Ext(x) => program.push(*x),
+        };
     }
 
     pub fn encode_program<I>(iterator: I, program: &mut Vec<u8>)

--- a/zkvm/src/ops.rs
+++ b/zkvm/src/ops.rs
@@ -195,67 +195,68 @@ impl Instruction {
     /// Appends the bytecode representation of an Instruction
     /// to the program.
     pub fn encode(&self, program: &mut Vec<u8>) {
+        let mut write = |op: Opcode| program.push(op.to_u8());
         match self {
             Instruction::Push(data) => {
-                program.push(Opcode::Push.to_u8());
+                write(Opcode::Push);
                 data.encode(program);
             }
-            Instruction::Drop => program.push(Opcode::Drop.to_u8()),
+            Instruction::Drop => write(Opcode::Drop),
             Instruction::Dup(idx) => {
-                program.push(Opcode::Dup.to_u8());
+                write(Opcode::Dup);
                 encoding::write_u32(*idx as u32, program);
             }
             Instruction::Roll(idx) => {
-                program.push(Opcode::Roll.to_u8());
+                write(Opcode::Roll);
                 encoding::write_u32(*idx as u32, program);
             }
-            Instruction::Const => program.push(Opcode::Const.to_u8()),
-            Instruction::Var => program.push(Opcode::Var.to_u8()),
-            Instruction::Alloc => program.push(Opcode::Alloc.to_u8()),
-            Instruction::Mintime => program.push(Opcode::Mintime.to_u8()),
-            Instruction::Maxtime => program.push(Opcode::Maxtime.to_u8()),
-            Instruction::Neg => program.push(Opcode::Neg.to_u8()),
-            Instruction::Add => program.push(Opcode::Add.to_u8()),
-            Instruction::Mul => program.push(Opcode::Mul.to_u8()),
-            Instruction::Eq => program.push(Opcode::Eq.to_u8()),
+            Instruction::Const => write(Opcode::Const),
+            Instruction::Var => write(Opcode::Var),
+            Instruction::Alloc => write(Opcode::Alloc),
+            Instruction::Mintime => write(Opcode::Mintime),
+            Instruction::Maxtime => write(Opcode::Maxtime),
+            Instruction::Neg => write(Opcode::Neg),
+            Instruction::Add => write(Opcode::Add),
+            Instruction::Mul => write(Opcode::Mul),
+            Instruction::Eq => write(Opcode::Eq),
             Instruction::Range(bit_width) => {
-                program.push(Opcode::Range.to_u8());
+                write(Opcode::Range);
                 program.push(*bit_width);
             }
-            Instruction::And => program.push(Opcode::And.to_u8()),
-            Instruction::Or => program.push(Opcode::Or.to_u8()),
-            Instruction::Verify => program.push(Opcode::Verify.to_u8()),
-            Instruction::Blind => program.push(Opcode::Blind.to_u8()),
-            Instruction::Reblind => program.push(Opcode::Reblind.to_u8()),
-            Instruction::Unblind => program.push(Opcode::Unblind.to_u8()),
-            Instruction::Issue => program.push(Opcode::Issue.to_u8()),
-            Instruction::Borrow => program.push(Opcode::Borrow.to_u8()),
-            Instruction::Retire => program.push(Opcode::Retire.to_u8()),
-            Instruction::Qty => program.push(Opcode::Qty.to_u8()),
-            Instruction::Flavor => program.push(Opcode::Flavor.to_u8()),
+            Instruction::And => write(Opcode::And),
+            Instruction::Or => write(Opcode::Or),
+            Instruction::Verify => write(Opcode::Verify),
+            Instruction::Blind => write(Opcode::Blind),
+            Instruction::Reblind => write(Opcode::Reblind),
+            Instruction::Unblind => write(Opcode::Unblind),
+            Instruction::Issue => write(Opcode::Issue),
+            Instruction::Borrow => write(Opcode::Borrow),
+            Instruction::Retire => write(Opcode::Retire),
+            Instruction::Qty => write(Opcode::Qty),
+            Instruction::Flavor => write(Opcode::Flavor),
             Instruction::Cloak(m, n) => {
-                program.push(Opcode::Cloak.to_u8());
+                write(Opcode::Cloak);
                 encoding::write_u32(*m as u32, program);
                 encoding::write_u32(*n as u32, program);
             }
-            Instruction::Import => program.push(Opcode::Import.to_u8()),
-            Instruction::Export => program.push(Opcode::Export.to_u8()),
-            Instruction::Input => program.push(Opcode::Input.to_u8()),
+            Instruction::Import => write(Opcode::Import),
+            Instruction::Export => write(Opcode::Export),
+            Instruction::Input => write(Opcode::Input),
             Instruction::Output(k) => {
-                program.push(Opcode::Output.to_u8());
+                write(Opcode::Output);
                 encoding::write_u32(*k as u32, program);
             }
             Instruction::Contract(k) => {
-                program.push(Opcode::Contract.to_u8());
+                write(Opcode::Contract);
                 encoding::write_u32(*k as u32, program);
             }
-            Instruction::Nonce => program.push(Opcode::Nonce.to_u8()),
-            Instruction::Log => program.push(Opcode::Log.to_u8()),
-            Instruction::Signtx => program.push(Opcode::Signtx.to_u8()),
-            Instruction::Call => program.push(Opcode::Call.to_u8()),
-            Instruction::Left => program.push(Opcode::Left.to_u8()),
-            Instruction::Right => program.push(Opcode::Right.to_u8()),
-            Instruction::Delegate => program.push(Opcode::Delegate.to_u8()),
+            Instruction::Nonce => write(Opcode::Nonce),
+            Instruction::Log => write(Opcode::Log),
+            Instruction::Signtx => write(Opcode::Signtx),
+            Instruction::Call => write(Opcode::Call),
+            Instruction::Left => write(Opcode::Left),
+            Instruction::Right => write(Opcode::Right),
+            Instruction::Delegate => write(Opcode::Delegate),
             Instruction::Ext(x) => program.push(*x),
         };
     }

--- a/zkvm/src/predicate.rs
+++ b/zkvm/src/predicate.rs
@@ -82,9 +82,9 @@ impl PredicateWitness {
         let gens = PedersenGens::default();
         match self {
             PredicateWitness::Key(s) => s * gens.B,
-            PredicateWitness::Or(b) => {
+            PredicateWitness::Or(l, r) => {
                 let mut t = Transcript::new(b"ZkVM.predicate");
-                let (left, right) = (&b.0.to_uncompressed_point(), &b.1.to_uncompressed_point());
+                let (left, right) = (&l.to_uncompressed_point(), &r.to_uncompressed_point());
                 t.commit_point(b"L", &left.compress());
                 t.commit_point(b"R", &right.compress());
                 let f = t.challenge_scalar(b"f");

--- a/zkvm/src/predicate.rs
+++ b/zkvm/src/predicate.rs
@@ -4,13 +4,15 @@
 //! - disjunction: P = L + f(L,R)*B
 //! - program_commitment: P = h(prog)*B2
 use bulletproofs::PedersenGens;
+use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
 use merlin::Transcript;
 
 use crate::errors::VMError;
+use crate::ops::Instruction;
 use crate::point_ops::PointOp;
 use crate::transcript::TranscriptProtocol;
-use crate::types::Predicate;
+use crate::types::{Predicate, PredicateWitness};
 
 impl Predicate {
     /// Computes a disjunction of two predicates.
@@ -68,6 +70,39 @@ impl Predicate {
             secondary: Some(h),
             arbitrary: vec![(-Scalar::one(), self.to_point())],
         }
+    }
+}
+
+impl PredicateWitness {
+    pub fn to_point(&self) -> CompressedRistretto {
+        self.to_uncompressed_point().compress()
+    }
+
+    fn to_uncompressed_point(&self) -> RistrettoPoint {
+        let gens = PedersenGens::default();
+        match self {
+            PredicateWitness::Key(s) => s * gens.B,
+            PredicateWitness::Or(b) => {
+                let mut t = Transcript::new(b"ZkVM.predicate");
+                let (left, right) = (&b.0.to_uncompressed_point(), &b.1.to_uncompressed_point());
+                t.commit_point(b"L", &left.compress());
+                t.commit_point(b"R", &right.compress());
+                let f = t.challenge_scalar(b"f");
+                left + f * gens.B
+            }
+            PredicateWitness::Program(prog) => {
+                let mut t = Transcript::new(b"ZkVM.predicate");
+                let mut bytecode = Vec::new();
+                Instruction::encode_program(prog.iter(), &mut bytecode);
+                t.commit_bytes(b"prog", &bytecode);
+                let h = t.challenge_scalar(b"h");
+                h * gens.B_blinding
+            }
+        }
+    }
+
+    pub fn encode(&self, program: &mut Vec<u8>) {
+        program.extend_from_slice(&self.to_point().to_bytes());
     }
 }
 

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -191,9 +191,9 @@ impl CommitmentWitness {
 }
 
 impl InputWitness {
-    // TBD: need initializer to construct InputWitness
-    fn destructure(&self) -> (&FrozenContract, UTXO, TxID) {
-        (&self.contract, self.utxo, self.txid)
+    fn encode(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(&self.txid.0);
+        self.contract.encode(buf);
     }
 }
 
@@ -371,12 +371,7 @@ impl DataWitness {
             DataWitness::Predicate(pw) => pw.encode(buf),
             DataWitness::Commitment(cw) => cw.encode(buf),
             DataWitness::Scalar(s) => buf.extend_from_slice(&s.to_bytes()),
-            DataWitness::Input(b) => {
-                // Input = PreviousTxID || PreviousOutput
-                let (contract, _, prev_txid) = b.destructure();
-                buf.extend_from_slice(&prev_txid.0);
-                contract.encode(buf);
-            }
+            DataWitness::Input(b) => b.encode(buf),
         }
     }
 }

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -329,6 +329,11 @@ impl Data {
             },
         }
     }
+
+    /// Encodes blinded Data values for txprogram bytecode.
+    pub fn encode(&self, program: &mut Vec<u8>) {
+        unimplemented!()
+    }
 }
 
 impl Contract {

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -644,7 +644,7 @@ where
     }
 
     fn encode_output(&mut self, contract: Contract) -> Vec<u8> {
-        let mut output = Vec::with_capacity(contract.exact_output_size());
+        let mut output = Vec::with_capacity(contract.min_output_size());
 
         encoding::write_point(&contract.predicate.to_point(), &mut output);
         encoding::write_u32(contract.payload.len() as u32, &mut output);

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -1,6 +1,5 @@
 use bulletproofs::r1cs;
 use bulletproofs::r1cs::R1CSProof;
-use byteorder::{ByteOrder, LittleEndian};
 use curve25519_dalek::ristretto::CompressedRistretto;
 use curve25519_dalek::scalar::Scalar;
 use spacesuit;

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -644,12 +644,11 @@ where
     }
 
     fn encode_output(&mut self, contract: Contract) -> Vec<u8> {
-        let mut output = Vec::with_capacity(contract.min_output_size());
+        let mut output = Vec::with_capacity(contract.min_serialized_length());
 
         encoding::write_point(&contract.predicate.to_point(), &mut output);
         encoding::write_u32(contract.payload.len() as u32, &mut output);
 
-        // can move all the write functions into type impl
         for item in contract.payload.iter() {
             match item {
                 PortableItem::Data(d) => match d {


### PR DESCRIPTION
Implements part of #61, to serialize the Prover's vec of Instructions into bytecode for the Verifier.

WIP: a few pieces missing around how best to implement Data `to_bytes` and `len`, as well as how to get the previous txID needed for `Input`