### PR TITLE
zkvm/predicate: move point into Predicate struct

### DIFF
--- a/zkvm/src/point_ops.rs
+++ b/zkvm/src/point_ops.rs
@@ -44,7 +44,7 @@ impl PointOp {
             .ok_or(VMError::PointOperationFailed)
     }
 
-    /// Non-batched verificatin of an individual point operation
+    /// Non-batched verification of an individual point operation
     pub fn verify(self) -> Result<(), VMError> {
         if !self.compute()?.is_identity() {
             return Err(VMError::PointOperationFailed);

--- a/zkvm/src/point_ops.rs
+++ b/zkvm/src/point_ops.rs
@@ -41,7 +41,7 @@ impl PointOp {
         }
 
         RistrettoPoint::optional_multiscalar_mul(weights, points)
-            .ok_or_else(|| VMError::PointOperationFailed)
+            .ok_or(VMError::PointOperationFailed)
     }
 
     /// Non-batched verificatin of an individual point operation
@@ -93,7 +93,7 @@ impl PointOp {
         }
 
         let check = RistrettoPoint::optional_multiscalar_mul(weights, points)
-            .ok_or_else(|| VMError::PointOperationFailed)?;
+            .ok_or(VMError::PointOperationFailed)?;
         if !check.is_identity() {
             return Err(VMError::PointOperationFailed);
         }

--- a/zkvm/src/point_ops.rs
+++ b/zkvm/src/point_ops.rs
@@ -1,7 +1,7 @@
 use bulletproofs::PedersenGens;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
-use curve25519_dalek::traits::{IsIdentity, VartimeMultiscalarMul};
+use curve25519_dalek::traits::{Identity, IsIdentity, VartimeMultiscalarMul};
 
 use super::errors::VMError;
 
@@ -21,8 +21,8 @@ pub struct PointOp {
 }
 
 impl PointOp {
-    /// Non-batched verification of an individual point operation.
-    pub fn verify(self) -> Result<(), VMError> {
+    /// Compute an individual point operation.
+    pub fn compute(self) -> Result<RistrettoPoint, VMError> {
         let gens = PedersenGens::default();
         let (mut weights, points): (Vec<_>, Vec<_>) = self.arbitrary.into_iter().unzip();
         let mut points: Vec<_> = points.into_iter().map(|p| p.decompress()).collect();
@@ -37,16 +37,18 @@ impl PointOp {
         }
 
         if points.len() == 0 {
-            return Ok(());
+            return Ok(RistrettoPoint::identity());
         }
 
-        let check = RistrettoPoint::optional_multiscalar_mul(weights, points)
-            .ok_or_else(|| VMError::PointOperationFailed)?;
+        RistrettoPoint::optional_multiscalar_mul(weights, points)
+            .ok_or_else(|| VMError::PointOperationFailed)
+    }
 
-        if !check.is_identity() {
+    /// Non-batched verificatin of an individual point operation
+    pub fn verify(self) -> Result<(), VMError> {
+        if !self.compute()?.is_identity() {
             return Err(VMError::PointOperationFailed);
         }
-
         Ok(())
     }
 

--- a/zkvm/src/predicate.rs
+++ b/zkvm/src/predicate.rs
@@ -23,7 +23,7 @@ impl Predicate {
     /// Computes a disjunction of two predicates.
     /// TBD: push this code into to_point() impl for the witness
     pub fn or(&self, right: &Predicate) -> Result<Predicate, VMError> {
-        Ok(Predicate::new(
+        Ok(Predicate::opaque(
             Self::commit_or(self.point(), right.point())
                 .compute()?
                 .compress(),
@@ -46,7 +46,7 @@ impl Predicate {
         let gens = PedersenGens::default();
         t.commit_bytes(b"prog", &prog);
         let h = t.challenge_scalar(b"h");
-        Predicate::new((h * gens.B_blinding).compress())
+        Predicate::opaque((h * gens.B_blinding).compress())
     }
 
     /// Verifies whether the current predicate is a commitment to a program `prog`.
@@ -133,8 +133,8 @@ mod tests {
         let gens = PedersenGens::default();
 
         // dummy predicates
-        let left = Predicate::new(gens.B.compress());
-        let right = Predicate::new(gens.B_blinding.compress());
+        let left = Predicate::opaque(gens.B.compress());
+        let right = Predicate::opaque(gens.B_blinding.compress());
 
         let pred = left.or(&right).unwrap();
         let op = pred.prove_or(&left, &right);
@@ -146,10 +146,10 @@ mod tests {
         let gens = PedersenGens::default();
 
         // dummy predicates
-        let left = Predicate::new(gens.B.compress());
-        let right = Predicate::new(gens.B_blinding.compress());
+        let left = Predicate::opaque(gens.B.compress());
+        let right = Predicate::opaque(gens.B_blinding.compress());
 
-        let pred = Predicate::new(gens.B.compress());
+        let pred = Predicate::opaque(gens.B.compress());
         let op = pred.prove_or(&left, &right);
         assert!(op.verify().is_err());
     }
@@ -159,8 +159,8 @@ mod tests {
         let gens = PedersenGens::default();
 
         // dummy predicates
-        let left = Predicate::new(gens.B.compress());
-        let right = Predicate::new(gens.B_blinding.compress());
+        let left = Predicate::opaque(gens.B.compress());
+        let right = Predicate::opaque(gens.B_blinding.compress());
 
         let pred = left.or(&right).unwrap();
         let op = pred.prove_or(&right, &left);

--- a/zkvm/src/predicate.rs
+++ b/zkvm/src/predicate.rs
@@ -59,7 +59,7 @@ impl Predicate {
 
     fn commit_or(left: CompressedRistretto, right: CompressedRistretto) -> PointOp {
         let mut t = Transcript::new(b"ZkVM.predicate");
-        let gens = PedersenGens::default();
+        
         t.commit_point(b"L", &left);
         t.commit_point(b"R", &right);
         let f = t.challenge_scalar(b"f");

--- a/zkvm/src/prover.rs
+++ b/zkvm/src/prover.rs
@@ -44,9 +44,9 @@ impl<'a, 'b> Delegate<r1cs::Prover<'a, 'b>> for Prover<'a, 'b> {
     }
 
     fn process_tx_signature(&mut self, pred: Predicate) -> Result<(), VMError> {
-        match pred {
-            Predicate::Opaque(_) => Err(VMError::WitnessMissing),
-            Predicate::Witness(w) => match *w {
+        match pred.witness {
+            None => Err(VMError::WitnessMissing),
+            Some(w) => match w {
                 PredicateWitness::Key(s) => Ok(self.signtx_keys.push(s)),
                 _ => Err(VMError::TypeNotKey),
             },

--- a/zkvm/src/prover.rs
+++ b/zkvm/src/prover.rs
@@ -44,7 +44,7 @@ impl<'a, 'b> Delegate<r1cs::Prover<'a, 'b>> for Prover<'a, 'b> {
     }
 
     fn process_tx_signature(&mut self, pred: Predicate) -> Result<(), VMError> {
-        match pred.witness {
+        match pred.witness() {
             None => Err(VMError::WitnessMissing),
             Some(w) => match w {
                 PredicateWitness::Key(s) => Ok(self.signtx_keys.push(s)),

--- a/zkvm/src/prover.rs
+++ b/zkvm/src/prover.rs
@@ -36,7 +36,7 @@ impl<'a, 'b> Delegate<r1cs::Prover<'a, 'b>> for Prover<'a, 'b> {
         Ok(self.cs.commit(v, v_blinding))
     }
 
-    fn verify_point_op<F>(&mut self, point_op_fn: F) -> Result<(), VMError>
+    fn verify_point_op<F>(&mut self, _point_op_fn: F) -> Result<(), VMError>
     where
         F: FnOnce() -> PointOp,
     {

--- a/zkvm/src/prover.rs
+++ b/zkvm/src/prover.rs
@@ -47,7 +47,7 @@ impl<'a, 'b> Delegate<r1cs::Prover<'a, 'b>> for Prover<'a, 'b> {
         match pred.witness() {
             None => Err(VMError::WitnessMissing),
             Some(w) => match w {
-                PredicateWitness::Key(s) => Ok(self.signtx_keys.push(s)),
+                PredicateWitness::Key(s) => Ok(self.signtx_keys.push(s.clone())),
                 _ => Err(VMError::TypeNotKey),
             },
         }

--- a/zkvm/src/prover.rs
+++ b/zkvm/src/prover.rs
@@ -8,6 +8,7 @@ use std::collections::VecDeque;
 use crate::errors::VMError;
 use crate::ops::Instruction;
 use crate::point_ops::PointOp;
+use crate::predicate::{Predicate, PredicateWitness};
 use crate::signature::Signature;
 use crate::txlog::{TxID, TxLog};
 use crate::types::*;

--- a/zkvm/src/signature.rs
+++ b/zkvm/src/signature.rs
@@ -11,6 +11,9 @@ use crate::errors::VMError;
 use crate::point_ops::PointOp;
 use crate::transcript::TranscriptProtocol;
 
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct VerificationKey(pub CompressedRistretto);
+
 #[derive(Copy, Clone, Debug)]
 pub struct Signature {
     R: CompressedRistretto,
@@ -137,9 +140,6 @@ impl Signature {
         buf
     }
 }
-
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub struct VerificationKey(pub CompressedRistretto);
 
 impl VerificationKey {
     // Constructs a VerificationKey from the private key.

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -10,9 +10,9 @@ use crate::encoding;
 use crate::encoding::Subslice;
 use crate::errors::VMError;
 use crate::ops::Instruction;
+use crate::predicate::Predicate;
 use crate::transcript::TranscriptProtocol;
 use crate::txlog::{TxID, UTXO};
-use crate::predicate::Predicate;
 
 #[derive(Debug)]
 pub enum Item {
@@ -211,7 +211,6 @@ impl Into<Scalar> for ScalarWitness {
         }
     }
 }
-
 
 impl Item {
     // Downcasts to Data type

--- a/zkvm/src/verifier.rs
+++ b/zkvm/src/verifier.rs
@@ -44,8 +44,8 @@ impl<'a, 'b> Delegate<r1cs::Verifier<'a, 'b>> for Verifier<'a, 'b> {
     }
 
     fn process_tx_signature(&mut self, pred: Predicate) -> Result<(), VMError> {
-        match pred.witness {
-            None => Ok(self.signtx_keys.push(VerificationKey(pred.point))),
+        match pred.witness() {
+            None => Ok(self.signtx_keys.push(VerificationKey(pred.point()))),
             Some(_) => Err(VMError::PredicateNotOpaque),
         }
     }

--- a/zkvm/src/verifier.rs
+++ b/zkvm/src/verifier.rs
@@ -44,9 +44,9 @@ impl<'a, 'b> Delegate<r1cs::Verifier<'a, 'b>> for Verifier<'a, 'b> {
     }
 
     fn process_tx_signature(&mut self, pred: Predicate) -> Result<(), VMError> {
-        match pred {
-            Predicate::Opaque(p) => Ok(self.signtx_keys.push(VerificationKey(p))),
-            Predicate::Witness(_) => Err(VMError::PredicateNotOpaque),
+        match pred.witness {
+            None => Ok(self.signtx_keys.push(VerificationKey(pred.point))),
+            Some(_) => Err(VMError::PredicateNotOpaque),
         }
     }
 

--- a/zkvm/src/verifier.rs
+++ b/zkvm/src/verifier.rs
@@ -7,6 +7,7 @@ use crate::encoding::*;
 use crate::errors::VMError;
 use crate::ops::Instruction;
 use crate::point_ops::PointOp;
+use crate::predicate::Predicate;
 use crate::signature::VerificationKey;
 use crate::types::*;
 

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -609,7 +609,7 @@ where
         //      Data  =  0x00  ||  LE32(len)  ||  <bytes>
         //     Value  =  0x01  ||  <32 bytes> ||  <32 bytes>
 
-        let predicate = Predicate::new(output.read_point()?);
+        let predicate = Predicate::opaque(output.read_point()?);
         let k = output.read_size()?;
 
         // sanity check: avoid allocating unreasonably more memory

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -288,7 +288,7 @@ where
 
     fn nonce(&mut self) -> Result<(), VMError> {
         let predicate = self.pop_item()?.to_data()?.to_predicate()?;
-        let point = predicate.to_point();
+        let point = predicate.point;
         let contract = Contract {
             predicate,
             payload: Vec::new(),
@@ -609,7 +609,7 @@ where
         //      Data  =  0x00  ||  LE32(len)  ||  <bytes>
         //     Value  =  0x01  ||  <32 bytes> ||  <32 bytes>
 
-        let predicate = Predicate::Opaque(output.read_point()?);
+        let predicate = Predicate::new(output.read_point()?);
         let k = output.read_size()?;
 
         // sanity check: avoid allocating unreasonably more memory
@@ -646,7 +646,7 @@ where
     fn encode_output(&mut self, contract: Contract) -> Vec<u8> {
         let mut output = Vec::with_capacity(contract.min_serialized_length());
 
-        encoding::write_point(&contract.predicate.to_point(), &mut output);
+        encoding::write_point(&contract.predicate.point, &mut output);
         encoding::write_u32(contract.payload.len() as u32, &mut output);
 
         for item in contract.payload.iter() {

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -11,6 +11,7 @@ use crate::encoding::Subslice;
 use crate::errors::VMError;
 use crate::ops::Instruction;
 use crate::point_ops::PointOp;
+use crate::predicate::Predicate;
 use crate::signature::*;
 use crate::txlog::{Entry, TxID, TxLog, UTXO};
 use crate::types::*;

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -288,7 +288,7 @@ where
 
     fn nonce(&mut self) -> Result<(), VMError> {
         let predicate = self.pop_item()?.to_data()?.to_predicate()?;
-        let point = predicate.point;
+        let point = predicate.point();
         let contract = Contract {
             predicate,
             payload: Vec::new(),
@@ -646,7 +646,7 @@ where
     fn encode_output(&mut self, contract: Contract) -> Vec<u8> {
         let mut output = Vec::with_capacity(contract.min_serialized_length());
 
-        encoding::write_point(&contract.predicate.point, &mut output);
+        encoding::write_point(&contract.predicate.point(), &mut output);
         encoding::write_u32(contract.payload.len() as u32, &mut output);
 
         for item in contract.payload.iter() {


### PR DESCRIPTION
First pass at the suggestion in https://github.com/interstellar/slingshot/pull/74, to move the `CompressedRistretto` representation of a predicate into the struct