### PR TITLE
slidechain/mockhorizon: use mock horizon in unit tests

### DIFF
--- a/slidechain/custodian.go
+++ b/slidechain/custodian.go
@@ -191,7 +191,7 @@ func (c *Custodian) Account(w http.ResponseWriter, req *http.Request) {
 // that stream txs, import, and export.
 func (c *Custodian) launch(ctx context.Context) {
 	go c.watchPegs(ctx)
-	go c.importFromPegs(ctx)
+	go c.importFromPegs(ctx, nil)
 	go c.watchExports(ctx)
 	go c.pegOutFromExports(ctx)
 }

--- a/slidechain/export.go
+++ b/slidechain/export.go
@@ -162,7 +162,7 @@ func buildPegOutTx(custodian, exporter, temp, network string, asset xdr.Asset, a
 // createTempAccount builds and submits a transaction to the Stellar
 // network that creates a new temporary account. It returns the
 // temporary account keypair and sequence number.
-func createTempAccount(hclient *horizon.Client, kp *keypair.Full) (*keypair.Full, xdr.SequenceNumber, error) {
+func createTempAccount(hclient horizon.ClientInterface, kp *keypair.Full) (*keypair.Full, xdr.SequenceNumber, error) {
 	root, err := hclient.Root()
 	if err != nil {
 		return nil, 0, errors.Wrap(err, "getting Horizon root")
@@ -202,7 +202,7 @@ func createTempAccount(hclient *horizon.Client, kp *keypair.Full) (*keypair.Full
 // to be a preauth transaction, which merges the account and pays
 // out the pegged-out funds.
 // The function returns the temporary account ID and sequence number.
-func SubmitPreExportTx(hclient *horizon.Client, kp *keypair.Full, custodian string, asset xdr.Asset, amount int64) (string, xdr.SequenceNumber, error) {
+func SubmitPreExportTx(hclient horizon.ClientInterface, kp *keypair.Full, custodian string, asset xdr.Asset, amount int64) (string, xdr.SequenceNumber, error) {
 	root, err := hclient.Root()
 	if err != nil {
 		return "", 0, errors.Wrap(err, "getting Horizon root")

--- a/slidechain/export_test.go
+++ b/slidechain/export_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/interstellar/slingshot/slidechain/mockhorizon"
 	"github.com/interstellar/slingshot/slidechain/stellar"
 	"github.com/stellar/go/clients/horizon"
 	"github.com/stellar/go/keypair"
@@ -29,7 +30,8 @@ func TestPegOut(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
-	c, err := newCustodian(ctx, db, "https://horizon-testnet.stellar.org")
+	hclient := mockhorizon.New()
+	c, err := newCustodian(ctx, db, hclient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/slidechain/import.go
+++ b/slidechain/import.go
@@ -62,19 +62,25 @@ func (c *Custodian) importFromPegs(ctx context.Context, ready chan struct{}) {
 		c.imports.L.Lock()
 		defer c.imports.L.Unlock()
 		log.Println("waiting")
+		if ready != nil {
+			log.Println("closing ready")
+			close(ready)
+		}
 		for {
 			if ctx.Err() != nil {
 				return
 			}
+			log.Println("pre-wait")
 			c.imports.Wait()
+			log.Println("post-wait")
 			ch <- struct{}{}
 		}
 	}()
 
-	if ready != nil {
-		log.Println("closing ready")
-		close(ready)
-	}
+	// if ready != nil {
+	// 	log.Println("closing ready")
+	// 	close(ready)
+	// }
 
 	for {
 		select {

--- a/slidechain/import.go
+++ b/slidechain/import.go
@@ -54,7 +54,7 @@ func (c *Custodian) buildImportTx(
 	return tx2, nil
 }
 
-func (c *Custodian) importFromPegs(ctx context.Context) {
+func (c *Custodian) importFromPegs(ctx context.Context, ready chan struct{}) {
 	defer log.Print("importFromPegs exiting")
 
 	ch := make(chan struct{})
@@ -69,6 +69,10 @@ func (c *Custodian) importFromPegs(ctx context.Context) {
 			ch <- struct{}{}
 		}
 	}()
+
+	if ready != nil {
+		close(ready)
+	}
 
 	for {
 		select {

--- a/slidechain/import.go
+++ b/slidechain/import.go
@@ -61,26 +61,17 @@ func (c *Custodian) importFromPegs(ctx context.Context, ready chan struct{}) {
 	go func() {
 		c.imports.L.Lock()
 		defer c.imports.L.Unlock()
-		log.Println("waiting")
 		if ready != nil {
-			log.Println("closing ready")
 			close(ready)
 		}
 		for {
 			if ctx.Err() != nil {
 				return
 			}
-			log.Println("pre-wait")
 			c.imports.Wait()
-			log.Println("post-wait")
 			ch <- struct{}{}
 		}
 	}()
-
-	// if ready != nil {
-	// 	log.Println("closing ready")
-	// 	close(ready)
-	// }
 
 	for {
 		select {
@@ -88,8 +79,6 @@ func (c *Custodian) importFromPegs(ctx context.Context, ready chan struct{}) {
 			return
 		case <-ch:
 		}
-
-		log.Println("received imports broadcast")
 
 		var (
 			amounts, expMSs                []int64

--- a/slidechain/import.go
+++ b/slidechain/import.go
@@ -77,6 +77,8 @@ func (c *Custodian) importFromPegs(ctx context.Context) {
 		case <-ch:
 		}
 
+		log.Println("received imports broadcast")
+
 		var (
 			amounts, expMSs                []int64
 			nonceHashes, assetXDRs, recips [][]byte

--- a/slidechain/import.go
+++ b/slidechain/import.go
@@ -61,6 +61,7 @@ func (c *Custodian) importFromPegs(ctx context.Context, ready chan struct{}) {
 	go func() {
 		c.imports.L.Lock()
 		defer c.imports.L.Unlock()
+		log.Println("waiting")
 		for {
 			if ctx.Err() != nil {
 				return
@@ -71,6 +72,7 @@ func (c *Custodian) importFromPegs(ctx context.Context, ready chan struct{}) {
 	}()
 
 	if ready != nil {
+		log.Println("closing ready")
 		close(ready)
 	}
 

--- a/slidechain/mockhorizon/mockhorizon.go
+++ b/slidechain/mockhorizon/mockhorizon.go
@@ -19,17 +19,17 @@ func New() *Client {
 	}
 }
 
+// Client is a mock Horizon client, implemengint the Horizon
+// client interface.
+//
+// Our mock implementation assumes that the calling functions
+// want to submit transactions and then stream to see if they
+// have been successfully included in the ledger.
 type Client struct {
 	txs       []string
 	mu        *sync.Mutex
 	submitted *sync.Cond
 }
-
-// Implement horizon.ClientInterface for mockhorizon.
-//
-// Our mock implementation assumes that the calling functions
-// want to submit transactions and then stream to see if they
-// have been successfully included in the ledger.
 
 // SubmitTransaction unmarshals the tx envelope string into a xdr.TransactionEnvelope,
 // and then adds the transaction to the Client's internal record of transactions to
@@ -47,7 +47,7 @@ func (c *Client) SubmitTransaction(txeBase64 string) (horizon.TransactionSuccess
 	return horizon.TransactionSuccess{}, nil
 }
 
-// StreamTransactions "streams" the transactions that have been submitted to SubmitTransaction.
+// StreamTransactions "streams" all transactions that have been submitted to SubmitTransaction.
 func (c *Client) StreamTransactions(ctx context.Context, accountID string, cursor *horizon.Cursor, handler horizon.TransactionHandler) error {
 	txindex := 0
 	ch := make(chan struct{})
@@ -71,9 +71,6 @@ func (c *Client) StreamTransactions(ctx context.Context, accountID string, curso
 		case <-ch:
 		}
 
-		// figure out how we exactly want to "stream" txs
-		// stream all the ones in the array
-		// and then wait for new ones?
 		c.mu.Lock()
 		txs := c.txs[txindex:]
 		c.mu.Unlock()

--- a/slidechain/mockhorizon/mockhorizon.go
+++ b/slidechain/mockhorizon/mockhorizon.go
@@ -1,0 +1,146 @@
+package mockhorizon
+
+import (
+	"context"
+	"sync"
+
+	"github.com/pkg/errors"
+	"github.com/stellar/go/clients/horizon"
+	"github.com/stellar/go/network"
+	"github.com/stellar/go/xdr"
+)
+
+// New returns a new instance of the mockhorizon
+// struct, which implements horizon.ClientInterface
+func New() *Client {
+	return &Client{
+		mu:        new(sync.Mutex),
+		submitted: sync.NewCond(new(sync.Mutex)),
+	}
+}
+
+type Client struct {
+	txs       []string
+	mu        *sync.Mutex
+	submitted *sync.Cond
+}
+
+// Implement horizon.ClientInterface for mockhorizon.
+//
+// Our mock implementation assumes that the calling functions
+// want to submit transactions and then stream to see if they
+// have been successfully included in the ledger.
+
+// SubmitTransaction unmarshals the tx envelope string into a xdr.TransactionEnvelope,
+// and then adds the transaction to the Client's internal record of transactions to
+// "stream".
+func (c *Client) SubmitTransaction(txeBase64 string) (horizon.TransactionSuccess, error) {
+	var txe xdr.TransactionEnvelope
+	err := xdr.SafeUnmarshalBase64(txeBase64, &txe)
+	if err != nil {
+		return horizon.TransactionSuccess{}, errors.Wrap(err, "submittx: unmarshaling tx envelope")
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.txs = append(c.txs, txeBase64)
+	c.submitted.Broadcast()
+	return horizon.TransactionSuccess{}, nil
+}
+
+// StreamTransactions "streams" the transactions that have been submitted to SubmitTransaction.
+func (c *Client) StreamTransactions(ctx context.Context, accountID string, cursor *horizon.Cursor, handler horizon.TransactionHandler) error {
+	txindex := 0
+	ch := make(chan struct{})
+
+	go func() {
+		c.submitted.L.Lock()
+		defer c.submitted.L.Unlock()
+		for {
+			if ctx.Err() != nil {
+				return
+			}
+			c.submitted.Wait()
+			ch <- struct{}{}
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ch:
+		}
+
+		// figure out how we exactly want to "stream" txs
+		// stream all the ones in the array
+		// and then wait for new ones?
+		c.mu.Lock()
+		txs := c.txs[txindex:]
+		c.mu.Unlock()
+
+		for _, tx := range txs {
+			htx := horizon.Transaction{EnvelopeXdr: tx}
+			handler(htx)
+			txindex++
+		}
+	}
+}
+
+// Unimplemented functions
+func (*Client) Root() (horizon.Root, error) {
+	return horizon.Root{
+		NetworkPassphrase: network.TestNetworkPassphrase,
+	}, nil
+}
+
+func (*Client) HomeDomainForAccount(aid string) (string, error) {
+	return "", nil
+}
+
+func (*Client) LoadAccount(accountID string) (horizon.Account, error) {
+	return horizon.Account{}, nil
+}
+
+func (*Client) LoadAccountOffers(accountID string, params ...interface{}) (horizon.OffersPage, error) {
+	return horizon.OffersPage{}, nil
+}
+
+func (*Client) LoadTradeAggregations(baseAsset, counterAsset horizon.Asset, resolution int64, params ...interface{}) (horizon.TradeAggregationsPage, error) {
+	return horizon.TradeAggregationsPage{}, nil
+}
+
+func (*Client) LoadTrades(baseAsset, counterAsset horizon.Asset, offerID, resolution int64, params ...interface{}) (horizon.TradesPage, error) {
+	return horizon.TradesPage{}, nil
+}
+
+func (*Client) LoadAccountMergeAmount(p *horizon.Payment) error {
+	return nil
+}
+
+func (*Client) LoadMemo(p *horizon.Payment) error {
+	return nil
+}
+
+func (*Client) LoadOperation(operationID string) (horizon.Payment, error) {
+	return horizon.Payment{}, nil
+}
+
+func (*Client) LoadOrderBook(selling, buying horizon.Asset, params ...interface{}) (horizon.OrderBookSummary, error) {
+	return horizon.OrderBookSummary{}, nil
+}
+
+func (*Client) LoadTransaction(transactionID string) (horizon.Transaction, error) {
+	return horizon.Transaction{}, nil
+}
+
+func (*Client) SequenceForAccount(accountID string) (xdr.SequenceNumber, error) {
+	return xdr.SequenceNumber(0), nil
+}
+
+func (*Client) StreamLedgers(ctx context.Context, cursor *horizon.Cursor, handler horizon.LedgerHandler) error {
+	return nil
+}
+
+func (*Client) StreamPayments(ctx context.Context, accountID string, cursor *horizon.Cursor, handler horizon.PaymentHandler) error {
+	return nil
+}

--- a/slidechain/slidechain_test.go
+++ b/slidechain/slidechain_test.go
@@ -241,6 +241,7 @@ func TestImport(t *testing.T) {
 			ready := make(chan struct{})
 			go c.importFromPegs(ctx, ready)
 			<-ready
+			log.Println("importFromPegs goroutine ready")
 			nonceHash := UniqueNonceHash(c.InitBlockHash.Bytes(), expMS)
 			_, err = db.Exec("INSERT INTO pegs (nonce_hash, amount, asset_xdr, recipient_pubkey, nonce_expms, stellar_tx) VALUES ($1, 1, $2, $3, $4, 1)", nonceHash[:], assetXDR, testRecipPubKey, expMS)
 			if err != nil {

--- a/slidechain/slidechain_test.go
+++ b/slidechain/slidechain_test.go
@@ -59,7 +59,9 @@ func makeAsset(typ xdr.AssetType, code string, issuer string) xdr.Asset {
 }
 
 func TestServer(t *testing.T) {
-	withTestServer(context.Background(), t, func(ctx context.Context, _ *sql.DB, _ *submitter, server *httptest.Server, _ *protocol.Chain) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+	withTestServer(ctx, t, func(ctx context.Context, _ *sql.DB, _ *submitter, server *httptest.Server, _ *protocol.Chain) {
 		resp, err := http.Get(server.URL + "/get")
 		if err != nil {
 			t.Fatalf("getting initial block from new server: %s", err)
@@ -189,6 +191,8 @@ var testRecipPubKey = mustDecodeHex("cca6ae12527fcb3f8d5648868a757ebb085a973b0fd
 const importTestAccountID = "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN"
 
 func TestImport(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
 	var importtests = []struct {
 		assetType xdr.AssetType
 		code      string
@@ -206,7 +210,7 @@ func TestImport(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		withTestServer(context.Background(), t, func(ctx context.Context, db *sql.DB, s *submitter, server *httptest.Server, chain *protocol.Chain) {
+		withTestServer(ctx, t, func(ctx context.Context, db *sql.DB, s *submitter, server *httptest.Server, chain *protocol.Chain) {
 			r := s.w.Reader()
 			defer r.Dispose()
 

--- a/slidechain/slidechain_test.go
+++ b/slidechain/slidechain_test.go
@@ -238,7 +238,9 @@ func TestImport(t *testing.T) {
 				t.Fatal("unsuccessfully waited on pre-peg-in tx hitting txvm")
 			}
 			log.Println("pre-peg-in tx hit the txvm chain...")
-			go c.importFromPegs(ctx)
+			ready := make(chan struct{})
+			go c.importFromPegs(ctx, ready)
+			<-ready
 			nonceHash := UniqueNonceHash(c.InitBlockHash.Bytes(), expMS)
 			_, err = db.Exec("INSERT INTO pegs (nonce_hash, amount, asset_xdr, recipient_pubkey, nonce_expms, stellar_tx) VALUES ($1, 1, $2, $3, $4, 1)", nonceHash[:], assetXDR, testRecipPubKey, expMS)
 			if err != nil {
@@ -258,8 +260,6 @@ func TestImport(t *testing.T) {
 						t.Logf("found import tx %x", tx.Program)
 						log.Printf("found import tx %x", tx.Program)
 						return
-					} else {
-						log.Printf("read tx %x, not import tx", tx.Program)
 					}
 				}
 			}

--- a/slidechain/stellar/tx.go
+++ b/slidechain/stellar/tx.go
@@ -11,7 +11,7 @@ import (
 
 // SignAndSubmitTx signs and submits a transaction to the Stellar network. If there is
 // an error, SubmitTx will log the Result string to the console and return the error.
-func SignAndSubmitTx(hclient *horizon.Client, tx *b.TransactionBuilder, seeds ...string) (*horizon.TransactionSuccess, error) {
+func SignAndSubmitTx(hclient horizon.ClientInterface, tx *b.TransactionBuilder, seeds ...string) (*horizon.TransactionSuccess, error) {
 	txenv, err := tx.Sign(seeds...)
 	if err != nil {
 		return nil, errors.Wrap(err, "signing tx")


### PR DESCRIPTION
Adds the `mockhorizon` package, defining a mock Horizon interface to use in place of making real calls to Horizon for unit tests (currently, `TestPegOut`). The integration test, `TestEndToEnd`, still calls out to a real Horizon server.