### PR TITLE
ZkVM: decode input string into Input object instead of directly into Contract

### DIFF
--- a/zkvm/src/contract.rs
+++ b/zkvm/src/contract.rs
@@ -115,7 +115,7 @@ impl PortableItem {
             PortableItem::Value(v) => {
                 let flv = commitments[v.flv.index].closed_commitment();
                 let qty = commitments[v.qty.index].closed_commitment();
-                FrozenItem::Value(FrozenValue{ flv, qty })
+                FrozenItem::Value(FrozenValue { flv, qty })
             }
         }
     }

--- a/zkvm/src/contract.rs
+++ b/zkvm/src/contract.rs
@@ -1,4 +1,5 @@
 use crate::encoding;
+use crate::errors::VMError;
 use crate::predicate::Predicate;
 use crate::txlog::{TxID, UTXO};
 use crate::types::{Commitment, Data, Value};
@@ -18,13 +19,7 @@ pub enum PortableItem {
 }
 
 #[derive(Clone, Debug)]
-pub enum Input {
-    Opaque(Vec<u8>),
-    Witness(Box<InputWitness>),
-}
-
-#[derive(Clone, Debug)]
-pub struct InputWitness {
+pub struct Input {
     contract: FrozenContract,
     utxo: UTXO,
     txid: TxID,
@@ -53,12 +48,6 @@ pub struct FrozenValue {
     pub(crate) flv: Commitment,
 }
 
-impl InputWitness {
-    pub fn encode(&self, buf: &mut Vec<u8>) {
-        buf.extend_from_slice(&self.txid.0);
-        self.contract.encode(buf);
-    }
-}
 
 impl Contract {
     pub fn min_serialized_length(&self) -> usize {
@@ -70,6 +59,18 @@ impl Contract {
             }
         }
         size
+    }
+}
+
+impl Input {
+    pub fn decode(data: Vec<u8>) -> Result<Self, VMError> {
+        // TBD: parse FrozenContract from data (copy from VM::decode_input).
+        unimplemented!()
+    }
+
+    pub fn encode(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(&self.txid.0);
+        self.contract.encode(buf);
     }
 }
 

--- a/zkvm/src/contract.rs
+++ b/zkvm/src/contract.rs
@@ -27,9 +27,9 @@ pub enum PortableItem {
 
 #[derive(Clone, Debug)]
 pub struct Input {
-    pub contract: FrozenContract,
-    pub utxo: UTXO,
-    pub txid: TxID,
+    pub(crate) contract: FrozenContract,
+    pub(crate) utxo: UTXO,
+    pub(crate) txid: TxID,
 }
 
 /// Representation of a Contract inside an Input that can be cloned.

--- a/zkvm/src/contract.rs
+++ b/zkvm/src/contract.rs
@@ -27,9 +27,9 @@ pub enum PortableItem {
 
 #[derive(Clone, Debug)]
 pub struct Input {
-    contract: FrozenContract,
-    utxo: UTXO,
-    txid: TxID,
+    pub contract: FrozenContract,
+    pub utxo: UTXO,
+    pub txid: TxID,
 }
 
 /// Representation of a Contract inside an Input that can be cloned.
@@ -89,10 +89,6 @@ impl Input {
     pub fn encode(&self, buf: &mut Vec<u8>) {
         buf.extend_from_slice(&self.txid.0);
         self.contract.encode(buf);
-    }
-
-    pub fn spend(self) -> Result<(Contract, UTXO), VMError> {
-        Ok((self.contract.thaw()?, self.utxo))
     }
 
     fn decode<'a>(mut input: Subslice<'a>) -> Result<Self, VMError> {
@@ -180,27 +176,5 @@ impl FrozenContract {
         }
 
         Ok(FrozenContract { predicate, payload })
-    }
-
-    pub fn thaw(self) -> Result<Contract, VMError> {
-        let mut payload = Vec::with_capacity(self.payload.len());
-        for item in self.payload.iter() {
-            payload.push(item.thaw()?)
-        }
-        Ok(Contract {
-            payload,
-            predicate: self.predicate,
-        })
-    }
-}
-
-impl FrozenItem {
-    pub fn thaw(&self) -> Result<PortableItem, VMError> {
-        match self {
-            FrozenItem::Data(d) => Ok(PortableItem::Data(d.clone())),
-            // TBD: how do we turn a frozen item into a
-            // variable with the current representation?
-            FrozenItem::Value(v) => unimplemented!(),
-        }
     }
 }

--- a/zkvm/src/contract.rs
+++ b/zkvm/src/contract.rs
@@ -1,8 +1,15 @@
 use crate::encoding;
+use crate::encoding::Subslice;
 use crate::errors::VMError;
 use crate::predicate::Predicate;
 use crate::txlog::{TxID, UTXO};
 use crate::types::{Commitment, Data, Value};
+
+/// Prefix for the data type in the Output Structure
+pub const DATA_TYPE: u8 = 0x00;
+
+/// Prefix for the value type in the Output Structure
+pub const VALUE_TYPE: u8 = 0x01;
 
 /// A ZkVM contract that holds a _payload_ (a list of portable items) protected by a _predicate_.
 #[derive(Debug)]
@@ -60,39 +67,97 @@ impl Contract {
         }
         size
     }
+
+    /// Half-way to encoding the contract
+    pub fn to_frozen(self) -> FrozenContract {
+        unimplemented!()
+    }
 }
 
 impl Input {
-    pub fn decode(data: Vec<u8>) -> Result<Self, VMError> {
-        // TBD: parse FrozenContract from data (copy from VM::decode_input).
-        unimplemented!()
+    pub fn from_bytes(data: Vec<u8>) -> Result<Self, VMError> {
+        Self::decode(Subslice::new(&data))
     }
 
     pub fn encode(&self, buf: &mut Vec<u8>) {
         buf.extend_from_slice(&self.txid.0);
         self.contract.encode(buf);
     }
+
+    fn decode<'a>(mut input: Subslice<'a>) -> Result<Self, VMError> {
+        // Input  =  PreviousTxID || PreviousOutput
+        // PreviousTxID  =  <32 bytes>
+        let txid = TxID(input.read_u8x32()?);
+        let output_slice = &input;
+        let contract = FrozenContract::decode(input)?;
+        let utxo = UTXO::from_output(output_slice, &txid);
+        Ok(Input {
+            contract,
+            utxo,
+            txid,
+        })
+    }
 }
 
 impl FrozenContract {
-    fn encode(&self, buf: &mut Vec<u8>) {
+    pub fn encode(&self, buf: &mut Vec<u8>) {
         buf.extend_from_slice(&self.predicate.point().to_bytes());
+        encoding::write_u32(self.payload.len() as u32, buf);
+
         for p in self.payload.iter() {
             match p {
                 // Data = 0x00 || LE32(len) || <bytes>
                 FrozenItem::Data(d) => {
-                    buf.push(0u8);
+                    buf.push(DATA_TYPE);
                     let mut bytes = d.to_bytes();
                     encoding::write_u32(bytes.len() as u32, buf);
                     buf.extend_from_slice(&mut bytes);
                 }
                 // Value = 0x01 || <32 bytes> || <32 bytes>
                 FrozenItem::Value(v) => {
-                    buf.push(1u8);
+                    buf.push(VALUE_TYPE);
                     buf.extend_from_slice(&v.qty.to_point().to_bytes());
                     buf.extend_from_slice(&v.flv.to_point().to_bytes());
                 }
             }
         }
+    }
+
+    fn decode<'a>(mut output: Subslice<'a>) -> Result<Self, VMError> {
+        //    Output  =  Predicate  ||  LE32(k)  ||  Item[0]  || ... ||  Item[k-1]
+        // Predicate  =  <32 bytes>
+        //      Item  =  enum { Data, Value }
+        //      Data  =  0x00  ||  LE32(len)  ||  <bytes>
+        //     Value  =  0x01  ||  <32 bytes> ||  <32 bytes>
+
+        let predicate = Predicate::opaque(output.read_point()?);
+        let k = output.read_size()?;
+
+        // sanity check: avoid allocating unreasonably more memory
+        // just because an untrusted length prefix says so.
+        if k > output.len() {
+            return Err(VMError::FormatError);
+        }
+
+        let mut payload: Vec<FrozenItem> = Vec::with_capacity(k);
+        for _ in 0..k {
+            let item = match output.read_u8()? {
+                DATA_TYPE => {
+                    let len = output.read_size()?;
+                    let bytes = output.read_bytes(len)?;
+                    FrozenItem::Data(Data::Opaque(bytes.to_vec()))
+                }
+                VALUE_TYPE => {
+                    let qty = Commitment::Closed(output.read_point()?);
+                    let flv = Commitment::Closed(output.read_point()?);
+
+                    FrozenItem::Value(FrozenValue { qty, flv })
+                }
+                _ => return Err(VMError::FormatError),
+            };
+            payload.push(item);
+        }
+
+        Ok(FrozenContract { predicate, payload })
     }
 }

--- a/zkvm/src/contract.rs
+++ b/zkvm/src/contract.rs
@@ -78,13 +78,14 @@ impl Input {
         self.contract.encode(buf);
     }
 
-    fn decode<'a>(mut input: Subslice<'a>) -> Result<Self, VMError> {
+    fn decode<'a>(mut reader: Subslice<'a>) -> Result<Self, VMError> {
         // Input  =  PreviousTxID || PreviousOutput
         // PreviousTxID  =  <32 bytes>
-        let txid = TxID(input.read_u8x32()?);
-        let output_slice = &input;
-        let contract = FrozenContract::decode(input)?;
-        let utxo = UTXO::from_output(output_slice, &txid);
+        let txid = TxID(reader.read_u8x32()?);
+        // Hash the contract into utxo before the subslice
+        // is advanced by the contract.decode method
+        let utxo = UTXO::from_output(&reader, &txid);
+        let contract = FrozenContract::decode(reader)?;
         Ok(Input {
             contract,
             utxo,

--- a/zkvm/src/contract.rs
+++ b/zkvm/src/contract.rs
@@ -196,6 +196,30 @@ impl FrozenContract {
     }
 }
 
+impl FrozenItem {
+    // Evaluates equality between two FrozenItems. Will return 
+    // false if both FrozenItems are witness data.
+    pub fn eq(&self, rhs: &Self) -> bool {
+        match (self, rhs) {
+            (FrozenItem::Data(ld), FrozenItem::Data(rd)) => {
+                match (ld, rd) {
+                    (Data::Opaque(lx), Data::Opaque(rx)) => {
+                        return lx == rx;
+                    },
+                    (_, _) => return false,
+                }
+            },
+            (FrozenItem::Value(lv), FrozenItem::Value(rv)) => {
+                if lv.flv.to_point() == rv.flv.to_point() && lv.qty.to_point() == rv.qty.to_point() {
+                    return true;
+                }
+                return false;
+            },
+            (_, _) => return false,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -219,8 +243,7 @@ mod tests {
                     Ok(decoded_fc) => {
                         assert_eq!(fc.predicate.point(), decoded_fc.predicate.point());
                         for (x, y) in fc.payload.iter().zip(decoded_fc.payload.iter()) {
-                            // TBD: implement FrozenItem.eq(...)
-                            unimplemented!()
+                            assert!(x.eq(y), "payload items do not match")
                         }
                     }
                     Err(err) => assert!(false, err),

--- a/zkvm/src/contract.rs
+++ b/zkvm/src/contract.rs
@@ -1,0 +1,97 @@
+use crate::encoding;
+use crate::predicate::Predicate;
+use crate::txlog::{TxID, UTXO};
+use crate::types::{Commitment, Data, Value};
+
+/// A ZkVM contract that holds a _payload_ (a list of portable items) protected by a _predicate_.
+#[derive(Debug)]
+pub struct Contract {
+    pub(crate) payload: Vec<PortableItem>,
+    pub(crate) predicate: Predicate,
+}
+
+/// Representation of items that can be stored within outputs and contracts.
+#[derive(Debug)]
+pub enum PortableItem {
+    Data(Data),
+    Value(Value),
+}
+
+#[derive(Clone, Debug)]
+pub enum Input {
+    Opaque(Vec<u8>),
+    Witness(Box<InputWitness>),
+}
+
+#[derive(Clone, Debug)]
+pub struct InputWitness {
+    contract: FrozenContract,
+    utxo: UTXO,
+    txid: TxID,
+}
+
+/// Representation of a Contract inside an Input that can be cloned.
+#[derive(Clone, Debug)]
+pub struct FrozenContract {
+    pub(crate) payload: Vec<FrozenItem>,
+    pub(crate) predicate: Predicate,
+}
+
+/// Representation of a PortableItem inside an Input that can be cloned.
+#[derive(Clone, Debug)]
+pub enum FrozenItem {
+    Data(Data),
+    Value(FrozenValue),
+}
+
+/// Representation of a Value inside an Input that can be cloned.
+/// Note: values do not necessarily have open commitments. Some can be reblinded,
+/// others can be passed-through to an output without going through `cloak` and the constraint system.
+#[derive(Clone, Debug)]
+pub struct FrozenValue {
+    pub(crate) qty: Commitment,
+    pub(crate) flv: Commitment,
+}
+
+impl InputWitness {
+    pub fn encode(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(&self.txid.0);
+        self.contract.encode(buf);
+    }
+}
+
+impl Contract {
+    pub fn min_serialized_length(&self) -> usize {
+        let mut size = 32 + 4;
+        for item in self.payload.iter() {
+            match item {
+                PortableItem::Data(d) => size += 1 + 4 + d.min_serialized_length(),
+                PortableItem::Value(_) => size += 1 + 64,
+            }
+        }
+        size
+    }
+}
+
+impl FrozenContract {
+    fn encode(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(&self.predicate.point().to_bytes());
+        for p in self.payload.iter() {
+            match p {
+                // Data = 0x00 || LE32(len) || <bytes>
+                FrozenItem::Data(d) => {
+                    buf.push(0u8);
+                    let mut bytes = d.to_bytes();
+                    encoding::write_u32(bytes.len() as u32, buf);
+                    buf.extend_from_slice(&mut bytes);
+                }
+                // Value = 0x01 || <32 bytes> || <32 bytes>
+                FrozenItem::Value(v) => {
+                    buf.push(1u8);
+                    buf.extend_from_slice(&v.qty.to_point().to_bytes());
+                    buf.extend_from_slice(&v.flv.to_point().to_bytes());
+                }
+            }
+        }
+    }
+}

--- a/zkvm/src/encoding.rs
+++ b/zkvm/src/encoding.rs
@@ -124,17 +124,12 @@ pub fn write_u32<'a>(x: u32, target: &mut Vec<u8>) {
     target.extend_from_slice(&buf);
 }
 
-/// Reads a 32-byte array and returns the subsequent slice
+/// Writes a 32-byte array and returns the subsequent slice
 pub fn write_bytes(x: &[u8], target: &mut Vec<u8>) {
     target.extend_from_slice(&x);
 }
 
-/// Reads a compressed point
+/// Writes a compressed point
 pub fn write_point(x: &CompressedRistretto, target: &mut Vec<u8>) {
-    write_bytes(x.as_bytes(), target);
-}
-
-/// Reads a scalar
-pub fn write_scalar(x: &Scalar, target: &mut Vec<u8>) {
     write_bytes(x.as_bytes(), target);
 }

--- a/zkvm/src/errors.rs
+++ b/zkvm/src/errors.rs
@@ -111,4 +111,7 @@ pub enum VMError {
 
     #[fail(display = "Predicate item must be opaque")]
     PredicateNotOpaque,
+
+    #[fail(display = "Variable commitment out of range.")]
+    CommitmentOutOfRange,
 }

--- a/zkvm/src/errors.rs
+++ b/zkvm/src/errors.rs
@@ -111,7 +111,4 @@ pub enum VMError {
 
     #[fail(display = "Predicate item must be opaque")]
     PredicateNotOpaque,
-
-    #[fail(display = "Variable commitment out of range.")]
-    CommitmentOutOfRange,
 }

--- a/zkvm/src/lib.rs
+++ b/zkvm/src/lib.rs
@@ -1,16 +1,7 @@
-extern crate byteorder;
-extern crate core;
-extern crate rand;
-
-extern crate bulletproofs;
-extern crate curve25519_dalek;
-extern crate merlin;
-extern crate spacesuit;
-extern crate subtle;
-
 #[macro_use]
 extern crate failure;
 
+mod contract;
 mod encoding;
 mod errors;
 mod ops;
@@ -24,8 +15,12 @@ mod types;
 mod verifier;
 mod vm;
 
+pub use self::contract::{Contract, FrozenContract, FrozenItem, FrozenValue, Input, PortableItem};
 pub use self::errors::VMError;
+pub use self::ops::{Instruction, Opcode};
+pub use self::predicate::{Predicate, PredicateWitness};
 pub use self::prover::Prover;
 pub use self::txlog::{Entry, TxID, UTXO};
+pub use self::types::{Commitment, Data, Item, Value, WideValue};
 pub use self::verifier::Verifier;
 pub use self::vm::{Tx, VerifiedTx};

--- a/zkvm/src/predicate.rs
+++ b/zkvm/src/predicate.rs
@@ -3,8 +3,7 @@
 //! Operations:
 //! - disjunction: P = L + f(L,R)*B
 //! - program_commitment: P = h(prog)*B2
-use bulletproofs::PedersenGens;
-use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
+use curve25519_dalek::ristretto::CompressedRistretto;
 use curve25519_dalek::scalar::Scalar;
 use merlin::Transcript;
 
@@ -141,6 +140,7 @@ impl PredicateWitness {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bulletproofs::PedersenGens;
 
     fn bytecode(prog: &Vec<Instruction>) -> Vec<u8> {
         let mut prog_vec = Vec::new();

--- a/zkvm/src/transcript.rs
+++ b/zkvm/src/transcript.rs
@@ -1,6 +1,5 @@
 //! Defines a `TranscriptProtocol` trait for using a Merlin transcript.
 
-use byteorder::{ByteOrder, LittleEndian};
 use curve25519_dalek::ristretto::CompressedRistretto;
 use curve25519_dalek::scalar::Scalar;
 use merlin::Transcript;
@@ -12,12 +11,6 @@ pub trait TranscriptProtocol {
     fn commit_point(&mut self, label: &'static [u8], point: &CompressedRistretto);
     /// Compute a `label`ed challenge variable.
     fn challenge_scalar(&mut self, label: &'static [u8]) -> Scalar;
-}
-
-fn le_u64(value: u64) -> [u8; 8] {
-    let mut value_bytes = [0u8; 8];
-    LittleEndian::write_u64(&mut value_bytes, value);
-    value_bytes
 }
 
 impl TranscriptProtocol for Transcript {

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -262,7 +262,7 @@ impl Data {
 
     pub fn to_input(self) -> Result<Input, VMError> {
         match self {
-            Data::Opaque(data) => Input::decode(data),
+            Data::Opaque(data) => Input::from_bytes(data),
             Data::Witness(witness) => match witness {
                 DataWitness::Input(i) => Ok(*i),
                 _ => Err(VMError::TypeNotInput),

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -295,13 +295,6 @@ impl DataWitness {
 }
 
 impl Value {
-    /// Converts a value to FrozenValue type.
-    pub fn to_frozen(&self) -> FrozenValue {
-        // TBD: should be impossible (?) to have Variable
-        // types from structured Instruction objects
-        unimplemented!()
-    }
-
     /// Computes a flavor as defined by the `issue` instruction from a predicate.
     pub fn issue_flavor(predicate: &Predicate) -> Scalar {
         let mut t = Transcript::new(b"ZkVM.issue");

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -6,7 +6,7 @@ use curve25519_dalek::scalar::Scalar;
 use merlin::Transcript;
 use spacesuit::SignedInteger;
 
-use crate::contract::{Contract, Input, InputWitness, PortableItem};
+use crate::contract::{Contract, Input, PortableItem};
 use crate::encoding::Subslice;
 use crate::errors::VMError;
 use crate::ops::Instruction;
@@ -78,7 +78,7 @@ pub enum DataWitness {
     Predicate(Box<Predicate>),
     Commitment(Box<CommitmentWitness>),
     Scalar(Box<Scalar>),
-    Input(Box<InputWitness>),
+    Input(Box<Input>),
 }
 
 /// Prover's representation of the commitment secret: witness and blinding factor
@@ -262,9 +262,9 @@ impl Data {
 
     pub fn to_input(self) -> Result<Input, VMError> {
         match self {
-            Data::Opaque(data) => Ok(Input::Opaque(data)),
+            Data::Opaque(data) => Input::decode(data),
             Data::Witness(witness) => match witness {
-                DataWitness::Input(w) => Ok(Input::Witness(w)),
+                DataWitness::Input(i) => Ok(*i),
                 _ => Err(VMError::TypeNotInput),
             },
         }

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -6,7 +6,7 @@ use curve25519_dalek::scalar::Scalar;
 use merlin::Transcript;
 use spacesuit::SignedInteger;
 
-use crate::contract::{Contract, FrozenValue, Input, PortableItem};
+use crate::contract::{Contract, Input, PortableItem};
 use crate::encoding::Subslice;
 use crate::errors::VMError;
 use crate::ops::Instruction;

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -6,7 +6,7 @@ use curve25519_dalek::scalar::Scalar;
 use merlin::Transcript;
 use spacesuit::SignedInteger;
 
-use crate::contract::{Contract, Input, PortableItem};
+use crate::contract::{Contract, FrozenValue, Input, PortableItem};
 use crate::encoding::Subslice;
 use crate::errors::VMError;
 use crate::ops::Instruction;
@@ -295,6 +295,13 @@ impl DataWitness {
 }
 
 impl Value {
+    /// Converts a value to FrozenValue type.
+    pub fn to_frozen(&self) -> FrozenValue {
+        // TBD: should be impossible (?) to have Variable
+        // types from structured Instruction objects
+        unimplemented!()
+    }
+
     /// Computes a flavor as defined by the `issue` instruction from a predicate.
     pub fn issue_flavor(predicate: &Predicate) -> Scalar {
         let mut t = Transcript::new(b"ZkVM.issue");

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -367,11 +367,10 @@ where
             .into_iter()
             .map(|i| match i {
                 PortableItem::Data(d) => FrozenItem::Data(d),
-                PortableItem::Value(v) => {
-                    let flv = self.variable_commitments[v.flv.index].closed_commitment();
-                    let qty = self.variable_commitments[v.qty.index].closed_commitment();
-                    FrozenItem::Value(FrozenValue { flv, qty })
-                }
+                PortableItem::Value(v) => FrozenItem::Value(FrozenValue {
+                    flv: Commitment::Closed(self.get_variable_commitment(v.flv)),
+                    qty: Commitment::Closed(self.get_variable_commitment(v.qty)),
+                }),
             })
             .collect::<Vec<_>>();
         FrozenContract {
@@ -610,12 +609,10 @@ where
             .into_iter()
             .map(|p| match p {
                 FrozenItem::Data(d) => PortableItem::Data(d),
-                FrozenItem::Value(v) => {
-                    let qty = self.make_variable(v.qty);
-                    let flv = self.make_variable(v.flv);
-                    let val = Value { qty, flv };
-                    PortableItem::Value(val)
-                }
+                FrozenItem::Value(v) => PortableItem::Value(Value {
+                    qty: self.make_variable(v.qty),
+                    flv: self.make_variable(v.flv),
+                }),
             })
             .collect::<Vec<_>>();
         Contract {
@@ -632,11 +629,5 @@ where
             bitrange,
         )
         .map_err(|_| VMError::R1CSInconsistency)
-    }
-}
-
-impl VariableCommitment {
-    pub fn closed_commitment(&self) -> Commitment {
-        Commitment::Closed(self.commitment.to_point())
     }
 }

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -365,14 +365,12 @@ where
         let frozen_items = contract
             .payload
             .into_iter()
-            .map(|i| {
-                match i {
-                    PortableItem::Data(d) => FrozenItem::Data(d),
-                    PortableItem::Value(v) => {
-                        let flv = self.variable_commitments[v.flv.index].closed_commitment();
-                        let qty = self.variable_commitments[v.qty.index].closed_commitment();
-                        FrozenItem::Value(FrozenValue { flv, qty })
-                    }
+            .map(|i| match i {
+                PortableItem::Data(d) => FrozenItem::Data(d),
+                PortableItem::Value(v) => {
+                    let flv = self.variable_commitments[v.flv.index].closed_commitment();
+                    let qty = self.variable_commitments[v.qty.index].closed_commitment();
+                    FrozenItem::Value(FrozenValue { flv, qty })
                 }
             })
             .collect::<Vec<_>>();
@@ -610,15 +608,13 @@ where
         let payload = contract
             .payload
             .into_iter()
-            .map(|p| {
-                match p {
-                    FrozenItem::Data(d) => PortableItem::Data(d),
-                    FrozenItem::Value(v) => {
-                        let qty = self.make_variable(v.qty);
-                        let flv = self.make_variable(v.flv);
-                        let val = Value { qty, flv };
-                        PortableItem::Value(val)
-                    }   
+            .map(|p| match p {
+                FrozenItem::Data(d) => PortableItem::Data(d),
+                FrozenItem::Value(v) => {
+                    let qty = self.make_variable(v.qty);
+                    let flv = self.make_variable(v.flv);
+                    let val = Value { qty, flv };
+                    PortableItem::Value(val)
                 }
             })
             .collect::<Vec<_>>();

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -357,7 +357,7 @@ where
         let contract = self.pop_contract(k)?;
         let mut buf = Vec::with_capacity(contract.min_serialized_length());
         contract
-            .to_frozen(&self.variable_commitments)
+            .to_frozen(&self.variable_commitments)?
             .encode(&mut buf);
         self.txlog.push(Entry::Output(buf));
         Ok(())

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -345,9 +345,9 @@ where
     /// _input_ **input** → _contract_
     fn input(&mut self) -> Result<(), VMError> {
         let input = self.pop_item()?.to_data()?.to_input()?;
-        let (contract, utxo) = self.spend_input(input)?;
+        let contract = self.unfreeze_contract(input.contract);
         self.push_item(contract);
-        self.txlog.push(Entry::Input(utxo));
+        self.txlog.push(Entry::Input(input.utxo));
         self.unique = true;
         Ok(())
     }
@@ -596,11 +596,6 @@ where
             Commitment::Closed(_) => None,
             Commitment::Open(w) => Some(w.value),
         }
-    }
-
-    fn spend_input(&mut self, input: Input) -> Result<(Contract, UTXO), VMError> {
-        let contract = self.unfreeze_contract(input.contract);
-        Ok((contract, input.utxo))
     }
 
     fn unfreeze_contract(&mut self, contract: FrozenContract) -> Contract {

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -359,7 +359,7 @@ where
     fn output(&mut self, k: usize) -> Result<(), VMError> {
         let contract = self.pop_contract(k)?;
         let mut buf = Vec::with_capacity(contract.min_serialized_length());
-        contract.to_frozen().encode(&mut buf);
+        contract.to_frozen(&self.variable_commitments).encode(&mut buf);
         self.txlog.push(Entry::Output(buf));
         Ok(())
     }
@@ -650,5 +650,11 @@ where
             bitrange,
         )
         .map_err(|_| VMError::R1CSInconsistency)
+    }
+}
+
+impl VariableCommitment {
+    pub fn closed_commitment(&self) -> Commitment {
+        Commitment::Closed(self.commitment.to_point())
     }
 }

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -6,9 +6,8 @@ use spacesuit;
 use spacesuit::SignedInteger;
 use std::iter::FromIterator;
 
-use crate::contract::{Contract, Input, PortableItem};
+use crate::contract::{Contract, Input, PortableItem, DATA_TYPE, VALUE_TYPE};
 use crate::encoding;
-use crate::encoding::Subslice;
 use crate::errors::VMError;
 use crate::ops::Instruction;
 use crate::point_ops::PointOp;
@@ -117,7 +116,8 @@ pub trait Delegate<CS: r1cs::ConstraintSystem> {
 
 /// And indirect reference to a high-level variable within a constraint system.
 /// Variable types store index of such commitments that allows replacing them.
-struct VariableCommitment {
+#[derive(Debug)]
+pub struct VariableCommitment {
     /// Pedersen commitment to a variable
     commitment: Commitment,
 
@@ -583,18 +583,12 @@ where
 
     fn spend_input(&mut self, input: Input) -> Result<(Contract, UTXO), VMError> {
         // TBD: create a contract out of a frozen contract
-        unimplemented!()
-        // match input {
-        //     Input::Opaque(data) => self.decode_input(data),
-        //     Input::Witness(_) => unimplemented!(),
-        // }
+        // Pass variables in from VM object
+        input.spend()
     }
 
     fn encode_output(&mut self, contract: Contract) -> Vec<u8> {
-        
-
         // TBD:  remove this method
-
 
         let mut output = Vec::with_capacity(contract.min_serialized_length());
 

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -587,12 +587,15 @@ where
     }
 
     fn spend_input(&mut self, input: Input) -> Result<(Contract, UTXO), VMError> {
-        match input {
-            Input::Opaque(data) => self.decode_input(data),
-            Input::Witness(_) => unimplemented!(),
-        }
+        // TBD: create a contract out of a frozen contract
+        unimplemented!()
+        // match input {
+        //     Input::Opaque(data) => self.decode_input(data),
+        //     Input::Witness(_) => unimplemented!(),
+        // }
     }
 
+    // TBD: move this into Input::decode
     fn decode_input(&mut self, data: Vec<u8>) -> Result<(Contract, UTXO), VMError> {
         // Input  =  PreviousTxID || PreviousOutput
         // PreviousTxID  =  <32 bytes>
@@ -604,6 +607,7 @@ where
         Ok((contract, utxo))
     }
 
+    // TBD: move this into Input::decode
     fn decode_output<'a>(&mut self, mut output: Subslice<'a>) -> Result<Contract, VMError> {
         //    Output  =  Predicate  ||  LE32(k)  ||  Item[0]  || ... ||  Item[k-1]
         // Predicate  =  <32 bytes>

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -6,6 +6,7 @@ use spacesuit;
 use spacesuit::SignedInteger;
 use std::iter::FromIterator;
 
+use crate::contract::{Contract, Input, PortableItem};
 use crate::encoding;
 use crate::encoding::Subslice;
 use crate::errors::VMError;


### PR DESCRIPTION
This allows decoupling parsing of the input from constructing a Contract instance and allocating necessary variables for the stored Values. The single method to convert FrozenContract into Contract becomes shared between Prover and Verifier.

* Contract-related code is moved to `contract.rs`
* `Input` and `InputWitness` are merged in one type `Input` which is constructed both by the Prover and Verifier when parsing the input string.
* Serialization code for inputs and outputs is grouped together in `contract.rs`


Closes #72.