### PR TITLE
zkvm: complete data witness conversion methods

### DIFF
--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -284,7 +284,7 @@ impl DataWitness {
             DataWitness::Scalar(s) => {
                 let s: Scalar = (*s.clone()).into();
                 buf.extend_from_slice(&s.to_bytes())
-            },
+            }
             DataWitness::Input(b) => b.encode(buf),
         }
     }
@@ -312,7 +312,6 @@ impl Expression {
 
 // Upcasting integers/scalars into ScalarWitness
 
-
 impl From<u64> for ScalarWitness {
     fn from(x: u64) -> Self {
         ScalarWitness::Integer(x.into())
@@ -325,19 +324,22 @@ impl From<Scalar> for ScalarWitness {
     }
 }
 
-
 // Upcasting all witness data types to Data and DataWitness
 
 // Anything convertible to DataWitness is also convertible to Data
 impl<T> From<T> for Data
-where T: Into<DataWitness> {
+where
+    T: Into<DataWitness>,
+{
     fn from(w: T) -> Self {
         Data::Witness(w.into())
     }
 }
 
 impl<T> From<T> for DataWitness
-where T: Into<ScalarWitness> {
+where
+    T: Into<ScalarWitness>,
+{
     fn from(x: T) -> Self {
         DataWitness::Scalar(Box::new(x.into()))
     }
@@ -360,7 +362,6 @@ impl From<Input> for DataWitness {
         DataWitness::Input(Box::new(x))
     }
 }
-
 
 // Upcasting all types to Item
 

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -76,7 +76,7 @@ pub enum Commitment {
 pub enum DataWitness {
     Program(Vec<Instruction>),
     Predicate(Box<Predicate>),
-    Commitment(Box<CommitmentWitness>),
+    Commitment(Box<Commitment>),
     Scalar(Box<ScalarWitness>),
     Input(Box<Input>),
 }
@@ -105,11 +105,8 @@ impl Commitment {
         }
     }
 
-    pub fn ensure_closed(&self) -> Result<CompressedRistretto, VMError> {
-        match self {
-            Commitment::Open(_) => Err(VMError::DataNotOpaque),
-            Commitment::Closed(x) => Ok(*x),
-        }
+    pub(crate) fn encode(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(&self.to_point().to_bytes());
     }
 }
 
@@ -117,10 +114,6 @@ impl CommitmentWitness {
     pub fn to_point(&self) -> CompressedRistretto {
         let gens = PedersenGens::default();
         gens.commit(self.value.into(), self.blinding).compress()
-    }
-
-    pub(crate) fn encode(&self, buf: &mut Vec<u8>) {
-        buf.extend_from_slice(&self.to_point().to_bytes());
     }
 }
 
@@ -254,7 +247,7 @@ impl Data {
                 Ok(Commitment::Closed(point))
             }
             Data::Witness(witness) => match witness {
-                DataWitness::Commitment(w) => Ok(Commitment::Open(w)),
+                DataWitness::Commitment(w) => Ok(*w),
                 _ => Err(VMError::TypeNotCommitment),
             },
         }
@@ -287,7 +280,7 @@ impl DataWitness {
         match self {
             DataWitness::Program(instr) => Instruction::encode_program(instr.iter(), buf),
             DataWitness::Predicate(pw) => pw.encode(buf),
-            DataWitness::Commitment(cw) => cw.encode(buf),
+            DataWitness::Commitment(c) => c.encode(buf),
             DataWitness::Scalar(s) => {
                 let s: Scalar = (*s.clone()).into();
                 buf.extend_from_slice(&s.to_bytes())
@@ -356,11 +349,11 @@ impl From<Predicate> for DataWitness {
     }
 }
 
-// impl From<Commitment> for DataWitness {
-//     fn from(x: Commitment) -> Self {
-//         DataWitness::Commitment(Box::new(x))
-//     }
-// }
+impl From<Commitment> for DataWitness {
+    fn from(x: Commitment) -> Self {
+        DataWitness::Commitment(Box::new(x))
+    }
+}
 
 impl From<Input> for DataWitness {
     fn from(x: Input) -> Self {

--- a/zkvm/src/verifier.rs
+++ b/zkvm/src/verifier.rs
@@ -31,7 +31,7 @@ impl<'a, 'b> Delegate<r1cs::Verifier<'a, 'b>> for Verifier<'a, 'b> {
         &mut self,
         com: &Commitment,
     ) -> Result<(CompressedRistretto, r1cs::Variable), VMError> {
-        let point = com.ensure_closed()?;
+        let point = com.to_point();
         let var = self.cs.commit(point);
         Ok((point, var))
     }


### PR DESCRIPTION
This adds conversion from specific witness types into Data and DataWitness and makes DataWitness support integers and closed commitments (which is valid for reblinding scenarios). Also removes `ensure_closed` as unnecessary.