### PR TITLE
spacesuit: fix the trait bound for the RngCore

### DIFF
--- a/spacesuit/benches/spacesuit.rs
+++ b/spacesuit/benches/spacesuit.rs
@@ -24,7 +24,7 @@ fn prove<R: Rng + CryptoRng>(
     pc_gens: &PedersenGens,
     inputs: &Vec<Value>,
     outputs: &Vec<Value>,
-    rng: &mut R,
+    mut rng: R,
 ) -> Result<(R1CSProof, Vec<CommittedValue>, Vec<CommittedValue>), R1CSError>
 where
     R: rand::RngCore,
@@ -32,8 +32,8 @@ where
     let mut prover_transcript = Transcript::new(b"TransactionTest");
     let mut prover = Prover::new(&bp_gens, &pc_gens, &mut prover_transcript);
 
-    let (in_com, in_vars) = inputs.commit(&mut prover, rng);
-    let (out_com, out_vars) = outputs.commit(&mut prover, rng);
+    let (in_com, in_vars) = inputs.commit(&mut prover, &mut rng);
+    let (out_com, out_vars) = outputs.commit(&mut prover, &mut rng);
 
     cloak(&mut prover, in_vars, out_vars)?;
     let proof = prover.prove()?;

--- a/spacesuit/src/value.rs
+++ b/spacesuit/src/value.rs
@@ -176,7 +176,9 @@ impl ProverCommittable for Vec<Value> {
     type Output = (Vec<CommittedValue>, Vec<AllocatedValue>);
 
     fn commit<R: RngCore + CryptoRng>(&self, prover: &mut Prover, mut rng: R) -> Self::Output {
-        self.iter().map(|value| value.commit(prover, &mut rng)).unzip()
+        self.iter()
+            .map(|value| value.commit(prover, &mut rng))
+            .unzip()
     }
 }
 

--- a/spacesuit/tests/spacesuit.rs
+++ b/spacesuit/tests/spacesuit.rs
@@ -28,7 +28,7 @@ fn prove<R: Rng + CryptoRng>(
     pc_gens: &PedersenGens,
     inputs: &Vec<Value>,
     outputs: &Vec<Value>,
-    rng: &mut R,
+    mut rng: R,
 ) -> Result<(R1CSProof, Vec<CommittedValue>, Vec<CommittedValue>), R1CSError>
 where
     R: rand::RngCore,
@@ -36,8 +36,8 @@ where
     let mut prover_transcript = Transcript::new(b"TransactionTest");
     let mut prover = Prover::new(&bp_gens, &pc_gens, &mut prover_transcript);
 
-    let (in_com, in_vars) = inputs.commit(&mut prover, rng);
-    let (out_com, out_vars) = outputs.commit(&mut prover, rng);
+    let (in_com, in_vars) = inputs.commit(&mut prover, &mut rng);
+    let (out_com, out_vars) = outputs.commit(&mut prover, &mut rng);
 
     cloak(&mut prover, in_vars, out_vars)?;
     let proof = prover.prove()?;


### PR DESCRIPTION
This fixes the issue triggered by the recent curve25519-dalek update to v1.1.

This is the issue:
<img width="908" alt="image" src="https://user-images.githubusercontent.com/698/52882522-cfffbd80-311c-11e9-8b68-6a61d2ba84e5.png">

```rust
error[E0382]: use of moved value: `rng`
   --> src/value.rs:161:70
    |
160 |         let (q_commit, q_var) = prover.commit(self.q.into(), Scalar::random(rng));
    |                                                                             --- value moved here
161 |         let (f_commit, f_var) = prover.commit(self.f, Scalar::random(rng));
    |                                                                      ^^^ value used here after move
    |
    = note: move occurs because `rng` has type `&mut R`, which does not implement the `Copy` trait
```

An issue on curve25519-dalek: https://github.com/dalek-cryptography/curve25519-dalek/issues/232