### PR TITLE
zkvm: revamp the predicate type

### DIFF
--- a/zkvm/src/contract.rs
+++ b/zkvm/src/contract.rs
@@ -95,7 +95,7 @@ impl Input {
 
 impl FrozenContract {
     pub fn encode(&self, buf: &mut Vec<u8>) {
-        buf.extend_from_slice(&self.predicate.point().to_bytes());
+        buf.extend_from_slice(&self.predicate.to_point().to_bytes());
         encoding::write_u32(self.payload.len() as u32, buf);
 
         for p in self.payload.iter() {
@@ -124,7 +124,7 @@ impl FrozenContract {
         //      Data  =  0x00  ||  LE32(len)  ||  <bytes>
         //     Value  =  0x01  ||  <32 bytes> ||  <32 bytes>
 
-        let predicate = Predicate::opaque(output.read_point()?);
+        let predicate = Predicate::Opaque(output.read_point()?);
         let k = output.read_size()?;
 
         // sanity check: avoid allocating unreasonably more memory

--- a/zkvm/src/errors.rs
+++ b/zkvm/src/errors.rs
@@ -112,7 +112,4 @@ pub enum VMError {
 
     #[fail(display = "Data item must be opaque")]
     DataNotOpaque,
-
-    #[fail(display = "Predicate item must be opaque")]
-    PredicateNotOpaque,
 }

--- a/zkvm/src/lib.rs
+++ b/zkvm/src/lib.rs
@@ -18,7 +18,7 @@ mod vm;
 pub use self::contract::{Contract, FrozenContract, FrozenItem, FrozenValue, Input, PortableItem};
 pub use self::errors::VMError;
 pub use self::ops::{Instruction, Opcode};
-pub use self::predicate::{Predicate, PredicateWitness};
+pub use self::predicate::Predicate;
 pub use self::prover::Prover;
 pub use self::signature::VerificationKey;
 pub use self::transcript::TranscriptProtocol;

--- a/zkvm/src/predicate.rs
+++ b/zkvm/src/predicate.rs
@@ -3,7 +3,7 @@
 //! Operations:
 //! - disjunction: P = L + f(L,R)*B
 //! - program_commitment: P = h(prog)*B2
-use curve25519_dalek::ristretto::CompressedRistretto;
+use curve25519_dalek::ristretto::{RistrettoPoint,CompressedRistretto};
 use curve25519_dalek::scalar::Scalar;
 use merlin::Transcript;
 
@@ -15,17 +15,18 @@ use crate::transcript::TranscriptProtocol;
 
 /// Represents a ZkVM predicate with its optional witness data.
 #[derive(Clone, Debug)]
-pub struct Predicate {
-    point: CompressedRistretto,
-    witness: Option<PredicateWitness>,
+pub enum Predicate {
+    Compressed(CompressedRistretto),
+    Decompressed(PredicateWitness),
 }
 
 /// Prover's representation of the predicate tree with all the secret witness data.
 #[derive(Clone, Debug)]
 pub enum PredicateWitness {
+    Opaque(RistrettoPoint),
     Key(Scalar),
     Program(Vec<Instruction>),
-    Or(Box<Predicate>, Box<Predicate>),
+    Or(Box<PredicateWitness>, Box<PredicateWitness>),
 }
 
 impl Predicate {

--- a/zkvm/src/predicate.rs
+++ b/zkvm/src/predicate.rs
@@ -82,14 +82,14 @@ impl Predicate {
         }
     }
 
-    /// Creates an opaque predicate witness from a compressed point
-    pub fn opaque_witness(point: CompressedRistretto) -> Result<Self, VMError> {
+    /// Creates a predicate with witness being an opaque branch of the tree.
+    pub fn opaque_branch(point: CompressedRistretto) -> Result<Self, VMError> {
         Ok(Predicate::Witness(PredicateWitness::OpaqueBranch(
             point.decompress().ok_or(VMError::FormatError)?,
         )))
     }
 
-    /// Creates a predicate with a signing key witness
+    /// Creates a predicate with a signing key witness.
     pub fn from_signing_key(secret_key: Scalar) -> Self {
         Predicate::Witness(PredicateWitness::Key(secret_key).into())
     }

--- a/zkvm/src/predicate.rs
+++ b/zkvm/src/predicate.rs
@@ -204,8 +204,8 @@ mod tests {
         let gens = PedersenGens::default();
 
         // dummy predicates
-        let left = Predicate::opaque_witness(gens.B.compress()).unwrap();
-        let right = Predicate::opaque_witness(gens.B_blinding.compress()).unwrap();
+        let left = Predicate::opaque_branch(gens.B.compress()).unwrap();
+        let right = Predicate::opaque_branch(gens.B_blinding.compress()).unwrap();
 
         let pred = left.clone().or(right.clone()).unwrap();
         let op = pred.prove_or(&left, &right);
@@ -217,8 +217,8 @@ mod tests {
         let gens = PedersenGens::default();
 
         // dummy predicates
-        let left = Predicate::opaque_witness(gens.B.compress()).unwrap();
-        let right = Predicate::opaque_witness(gens.B_blinding.compress()).unwrap();
+        let left = Predicate::opaque_branch(gens.B.compress()).unwrap();
+        let right = Predicate::opaque_branch(gens.B_blinding.compress()).unwrap();
 
         let pred = Predicate::Opaque(gens.B.compress());
         let op = pred.prove_or(&left, &right);
@@ -230,8 +230,8 @@ mod tests {
         let gens = PedersenGens::default();
 
         // dummy predicates
-        let left = Predicate::opaque_witness(gens.B.compress()).unwrap();
-        let right = Predicate::opaque_witness(gens.B_blinding.compress()).unwrap();
+        let left = Predicate::opaque_branch(gens.B.compress()).unwrap();
+        let right = Predicate::opaque_branch(gens.B_blinding.compress()).unwrap();
 
         let pred = left.clone().or(right.clone()).unwrap();
         let op = pred.prove_or(&right, &left);

--- a/zkvm/src/predicate.rs
+++ b/zkvm/src/predicate.rs
@@ -27,10 +27,17 @@ pub enum Predicate {
 /// Prover's representation of the predicate tree with all the secret witness data.
 #[derive(Clone, Debug)]
 pub enum PredicateWitness {
-    // Externally provided opaque predicate, but known to be a valid Ristretto point.
+    /// Representation of an opaque branch of the predicate tree
+    /// (but known to be a valid Ristretto point).
     Opaque(RistrettoPoint),
+
+    /// Secret signing key for the predicate-as-a-verification-key.
     Key(Scalar),
+
+    /// Representation of a predicate as commitment to a program.
     Program(Vec<Instruction>),
+
+    /// Disjunction of two predicates.
     Or(Box<PredicateWitness>, Box<PredicateWitness>),
 }
 

--- a/zkvm/src/predicate.rs
+++ b/zkvm/src/predicate.rs
@@ -29,7 +29,7 @@ pub enum Predicate {
 pub enum PredicateWitness {
     /// Representation of an opaque branch of the predicate tree
     /// (but known to be a valid Ristretto point).
-    Opaque(RistrettoPoint),
+    OpaqueBranch(RistrettoPoint),
 
     /// Secret signing key for the predicate-as-a-verification-key.
     Key(Scalar),
@@ -84,7 +84,7 @@ impl Predicate {
 
     /// Creates an opaque predicate witness from a compressed point
     pub fn opaque_witness(point: CompressedRistretto) -> Result<Self, VMError> {
-        Ok(Predicate::Witness(PredicateWitness::Opaque(
+        Ok(Predicate::Witness(PredicateWitness::OpaqueBranch(
             point.decompress().ok_or(VMError::FormatError)?,
         )))
     }
@@ -141,7 +141,7 @@ impl Predicate {
 impl PredicateWitness {
     fn to_uncompressed_point(&self) -> RistrettoPoint {
         match self {
-            PredicateWitness::Opaque(p) => *p,
+            PredicateWitness::OpaqueBranch(p) => *p,
             PredicateWitness::Key(s) => VerificationKey::from_secret_uncompressed(s),
             PredicateWitness::Or(l, r) => {
                 let l = l.to_uncompressed_point();

--- a/zkvm/src/prover.rs
+++ b/zkvm/src/prover.rs
@@ -45,7 +45,7 @@ impl<'a, 'b> Delegate<r1cs::Prover<'a, 'b>> for Prover<'a, 'b> {
     }
 
     fn process_tx_signature(&mut self, pred: Predicate) -> Result<(), VMError> {
-        match pred.witness() {
+        match pred.as_witness() {
             None => Err(VMError::WitnessMissing),
             Some(w) => match w {
                 PredicateWitness::Key(s) => Ok(self.signtx_keys.push(s.clone())),

--- a/zkvm/src/prover.rs
+++ b/zkvm/src/prover.rs
@@ -8,7 +8,7 @@ use std::collections::VecDeque;
 use crate::errors::VMError;
 use crate::ops::Instruction;
 use crate::point_ops::PointOp;
-use crate::predicate::{Predicate, PredicateWitness};
+use crate::predicate::Predicate;
 use crate::signature::Signature;
 use crate::txlog::{TxID, TxLog};
 use crate::types::*;
@@ -45,13 +45,9 @@ impl<'a, 'b> Delegate<r1cs::Prover<'a, 'b>> for Prover<'a, 'b> {
     }
 
     fn process_tx_signature(&mut self, pred: Predicate) -> Result<(), VMError> {
-        match pred.as_witness() {
-            None => Err(VMError::WitnessMissing),
-            Some(w) => match w {
-                PredicateWitness::Key(s) => Ok(self.signtx_keys.push(s.clone())),
-                _ => Err(VMError::TypeNotKey),
-            },
-        }
+        let k = pred.to_signing_key()?;
+        self.signtx_keys.push(k);
+        Ok(())
     }
 
     fn next_instruction(

--- a/zkvm/src/signature.rs
+++ b/zkvm/src/signature.rs
@@ -3,7 +3,7 @@
 #![allow(non_snake_case)]
 
 use bulletproofs::PedersenGens;
-use curve25519_dalek::ristretto::CompressedRistretto;
+use curve25519_dalek::ristretto::{RistrettoPoint,CompressedRistretto};
 use curve25519_dalek::scalar::Scalar;
 use merlin::Transcript;
 
@@ -144,8 +144,13 @@ impl Signature {
 impl VerificationKey {
     // Constructs a VerificationKey from the private key.
     pub fn from_secret(privkey: &Scalar) -> Self {
+        VerificationKey(Self::from_secret_uncompressed(privkey).compress())
+    }
+
+    // Constructs a VerificationKey from the private key.
+    pub(crate) fn from_secret_uncompressed(privkey: &Scalar) -> RistrettoPoint {
         let gens = PedersenGens::default();
-        VerificationKey((privkey * gens.B).compress())
+        (privkey * gens.B)
     }
 }
 

--- a/zkvm/src/signature.rs
+++ b/zkvm/src/signature.rs
@@ -142,12 +142,12 @@ impl Signature {
 }
 
 impl VerificationKey {
-    // Constructs a VerificationKey from the private key.
+    // Constructs a VerificationKey from a private key.
     pub fn from_secret(privkey: &Scalar) -> Self {
         VerificationKey(Self::from_secret_uncompressed(privkey).compress())
     }
 
-    // Constructs a VerificationKey from the private key.
+    // Constructs an uncompressed VerificationKey point from a private key.
     pub(crate) fn from_secret_uncompressed(privkey: &Scalar) -> RistrettoPoint {
         let gens = PedersenGens::default();
         (privkey * gens.B)

--- a/zkvm/src/signature.rs
+++ b/zkvm/src/signature.rs
@@ -3,7 +3,7 @@
 #![allow(non_snake_case)]
 
 use bulletproofs::PedersenGens;
-use curve25519_dalek::ristretto::{RistrettoPoint,CompressedRistretto};
+use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
 use merlin::Transcript;
 

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -251,7 +251,7 @@ impl Data {
         match self {
             Data::Opaque(data) => {
                 let point = SliceReader::parse(&data, |r| r.read_point())?;
-                Ok(Predicate::opaque(point))
+                Ok(Predicate::Opaque(point))
             }
             Data::Witness(witness) => match witness {
                 DataWitness::Predicate(boxed_pred) => Ok(*boxed_pred),
@@ -316,7 +316,7 @@ impl Value {
     /// Computes a flavor as defined by the `issue` instruction from a predicate.
     pub fn issue_flavor(predicate: &Predicate) -> Scalar {
         let mut t = Transcript::new(b"ZkVM.issue");
-        t.commit_bytes(b"predicate", predicate.point().as_bytes());
+        t.commit_bytes(b"predicate", predicate.to_point().as_bytes());
         t.challenge_scalar(b"flavor")
     }
 }

--- a/zkvm/src/verifier.rs
+++ b/zkvm/src/verifier.rs
@@ -45,10 +45,7 @@ impl<'a, 'b> Delegate<r1cs::Verifier<'a, 'b>> for Verifier<'a, 'b> {
     }
 
     fn process_tx_signature(&mut self, pred: Predicate) -> Result<(), VMError> {
-        match pred.witness() {
-            None => Ok(self.signtx_keys.push(VerificationKey(pred.point()))),
-            Some(_) => Err(VMError::PredicateNotOpaque),
-        }
+        Ok(self.signtx_keys.push(VerificationKey(pred.to_point())))
     }
 
     fn next_instruction(

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -12,7 +12,7 @@ use crate::encoding::SliceReader;
 use crate::errors::VMError;
 use crate::ops::Instruction;
 use crate::point_ops::PointOp;
-use crate::predicate::{Predicate, PredicateWitness};
+use crate::predicate::Predicate;
 use crate::signature::*;
 use crate::txlog::{Entry, TxID, TxLog};
 use crate::types::*;

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -331,7 +331,7 @@ where
 
     fn nonce(&mut self) -> Result<(), VMError> {
         let predicate = self.pop_item()?.to_data()?.to_predicate()?;
-        let point = predicate.point();
+        let point = predicate.to_point();
         let contract = Contract {
             predicate,
             payload: Vec::new(),

--- a/zkvm/tests/zkvm.rs
+++ b/zkvm/tests/zkvm.rs
@@ -38,9 +38,9 @@ fn issue_contract(
 fn issue() {
     let (tx, txid, txlog) = {
         // Generate predicates
-        let issuance_pred = PredicateWitness::Key(Scalar::from(0u64)).to_predicate();
-        let nonce_pred = PredicateWitness::Key(Scalar::from(1u64)).to_predicate();
-        let recipient_pred = PredicateWitness::Key(Scalar::from(2u64)).to_predicate();
+        let issuance_pred = Predicate::from_signing_key(Scalar::from(0u64));
+        let nonce_pred = Predicate::from_signing_key(Scalar::from(1u64));
+        let recipient_pred = Predicate::from_signing_key(Scalar::from(2u64));
 
         // Generate flavor scalar
         let mut t = Transcript::new(b"ZkVM.issue");

--- a/zkvm/tests/zkvm.rs
+++ b/zkvm/tests/zkvm.rs
@@ -38,16 +38,13 @@ fn issue_contract(
 fn issue() {
     let (tx, txid, txlog) = {
         // Generate predicates
-        let issuance_pred =
-            Predicate::from_witness(PredicateWitness::Key(Scalar::from(0u64))).unwrap();
-        let nonce_pred =
-            Predicate::from_witness(PredicateWitness::Key(Scalar::from(1u64))).unwrap();
-        let recipient_pred =
-            Predicate::from_witness(PredicateWitness::Key(Scalar::from(2u64))).unwrap();
+        let issuance_pred = PredicateWitness::Key(Scalar::from(0u64)).to_predicate();
+        let nonce_pred = PredicateWitness::Key(Scalar::from(1u64)).to_predicate();
+        let recipient_pred = PredicateWitness::Key(Scalar::from(2u64)).to_predicate();
 
         // Generate flavor scalar
         let mut t = Transcript::new(b"ZkVM.issue");
-        t.commit_bytes(b"predicate", issuance_pred.point().as_bytes());
+        t.commit_bytes(b"predicate", issuance_pred.to_point().as_bytes());
         let flavor = t.challenge_scalar(b"flavor");
 
         // Build program


### PR DESCRIPTION
1. Makes conversion from predicate witness to predicate non-failable, so we can use From/Into traits.
2. Clarifies distinction between the opaque predicate (as viewed by the Verifier) and opaque witness for a predicate (an opaque branch in a predicate tree as viewed by the Prover).