### PR TITLE
zkvm/encoding: safer subslice parsing

### DIFF
--- a/zkvm/src/contract.rs
+++ b/zkvm/src/contract.rs
@@ -70,7 +70,7 @@ impl Contract {
 
 impl Input {
     pub fn from_bytes(data: Vec<u8>) -> Result<Self, VMError> {
-        let contract = SliceReader::parse(&data, |mut r| Self::decode(&mut r))?;
+        let contract = SliceReader::parse(&data, |r| Self::decode(r))?;
         Ok(contract)
     }
 

--- a/zkvm/src/encoding.rs
+++ b/zkvm/src/encoding.rs
@@ -5,20 +5,19 @@ use byteorder::{ByteOrder, LittleEndian};
 use core::ops::Range;
 use curve25519_dalek::ristretto::CompressedRistretto;
 use curve25519_dalek::scalar::Scalar;
-use std::ops::Deref;
 
 use crate::errors::VMError;
 
 #[derive(Copy, Clone, Debug)]
-pub struct Subslice<'a> {
+pub struct SliceReader<'a> {
     whole: &'a [u8],
     start: usize,
     end: usize,
 }
 
-impl<'a> Subslice<'a> {
-    pub fn new(data: &'a [u8]) -> Self {
-        Subslice {
+impl<'a> SliceReader<'a> {
+    fn new(data: &'a [u8]) -> Self {
+        SliceReader {
             start: 0,
             end: data.len(),
             whole: data,
@@ -29,7 +28,7 @@ impl<'a> Subslice<'a> {
         if range.end > data.len() || range.start > data.len() {
             return Err(VMError::FormatError);
         }
-        Ok(Subslice {
+        Ok(SliceReader {
             start: range.start,
             end: range.end,
             whole: data,
@@ -44,26 +43,45 @@ impl<'a> Subslice<'a> {
         self.start..self.end
     }
 
-    /// Copies the contents of the subslice into a `Vec<u8>`.
-    pub fn to_vec(&self) -> Vec<u8> {
-        let mut buf = Vec::with_capacity(self.len());
-        buf.extend_from_slice(&self);
-        buf
+    pub fn slice<F, T>(&mut self, slice_fn: F) -> Result<(T, &[u8]), VMError>
+    where
+        F: FnOnce(&mut SliceReader) -> Result<T, VMError>,
+    {
+        let start = self.start;
+        let result = slice_fn(self)?;
+        let end = self.start;
+        Ok((result, &self.whole[start..end]))
     }
 
-    /// Returns a Subslice of the first `prefix_size` of bytes and advances
+    pub fn parse<F, T>(data: &[u8], parse_fn: F) -> Result<T, VMError>
+    where
+        F: FnOnce(SliceReader) -> Result<T, VMError>,
+    {
+        let reader = SliceReader::new(data);
+        let result = parse_fn(reader)?;
+        if reader.len() != 0 {
+            return Err(VMError::FormatError);
+        }
+        Ok(result)
+    }
+
+    pub fn skip_trailing_bytes(&mut self) -> usize {
+        unimplemented!()
+    }
+
+    /// Returns a slice of the first `prefix_size` of bytes and advances
     /// the internal offset.
-    pub fn read_bytes(&mut self, prefix_size: usize) -> Result<Subslice, VMError> {
+    pub fn read_bytes(&mut self, prefix_size: usize) -> Result<&[u8], VMError> {
         if prefix_size > self.len() {
             return Err(VMError::FormatError);
         }
-        let prefix = Subslice {
+        let prefix = SliceReader {
             start: self.start,
             end: self.start + prefix_size,
             whole: self.whole,
         };
         self.start = self.start + prefix_size;
-        Ok(prefix)
+        Ok(&prefix.whole[prefix.range()])
     }
 
     pub fn read_u8(&mut self) -> Result<u8, VMError> {
@@ -98,14 +116,6 @@ impl<'a> Subslice<'a> {
     pub fn read_scalar(&mut self) -> Result<Scalar, VMError> {
         let buf = self.read_u8x32()?;
         Scalar::from_canonical_bytes(buf).ok_or(VMError::FormatError)
-    }
-}
-
-impl<'a> Deref for Subslice<'a> {
-    type Target = [u8];
-
-    fn deref(&self) -> &[u8] {
-        &self.whole[self.start..self.end]
     }
 }
 

--- a/zkvm/src/errors.rs
+++ b/zkvm/src/errors.rs
@@ -15,6 +15,10 @@ pub enum VMError {
     #[fail(display = "Format in invalid")]
     FormatError,
 
+    /// This error occurs when there are trailing bytes left unread.
+    #[fail(display = "Invalid trailing bytes.")]
+    TrailingBytes,
+
     /// This error occurs when data is malformed
     #[fail(display = "Transaction version does not permit extension instructions.")]
     ExtensionsNotAllowed,

--- a/zkvm/src/errors.rs
+++ b/zkvm/src/errors.rs
@@ -15,7 +15,7 @@ pub enum VMError {
     #[fail(display = "Format in invalid")]
     FormatError,
 
-    /// This error occurs when there are trailing bytes left unread.
+    /// This error occurs when there are trailing bytes left unread by the parser.
     #[fail(display = "Invalid trailing bytes.")]
     TrailingBytes,
 

--- a/zkvm/src/ops.rs
+++ b/zkvm/src/ops.rs
@@ -2,7 +2,7 @@ use core::borrow::Borrow;
 use core::mem;
 
 use crate::encoding;
-use crate::encoding::Subslice;
+use crate::encoding::SliceReader;
 use crate::errors::VMError;
 use crate::types::Data;
 
@@ -118,7 +118,7 @@ impl Instruction {
     ///
     /// Return `VMError::FormatError` if there are not enough bytes to parse an
     /// instruction.
-    pub fn parse(program: &mut Subslice) -> Result<Self, VMError> {
+    pub fn parse(program: &mut SliceReader) -> Result<Self, VMError> {
         let byte = program.read_u8()?;
 
         // Interpret the opcode. Unknown opcodes are extension opcodes.

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -7,8 +7,7 @@ use merlin::Transcript;
 use spacesuit::SignedInteger;
 
 use crate::contract::{Contract, Input, PortableItem};
-use crate::encoding;
-use crate::encoding::Subslice;
+use crate::encoding::SliceReader;
 use crate::errors::VMError;
 use crate::ops::Instruction;
 use crate::predicate::Predicate;
@@ -251,7 +250,7 @@ impl Data {
     pub fn to_predicate(self) -> Result<Predicate, VMError> {
         match self {
             Data::Opaque(data) => {
-                let point = Subslice::new(&data).read_point()?;
+                let point = SliceReader::parse(&data, |mut r| r.read_point())?;
                 Ok(Predicate::opaque(point))
             }
             Data::Witness(witness) => match witness {
@@ -264,7 +263,7 @@ impl Data {
     pub fn to_commitment(self) -> Result<Commitment, VMError> {
         match self {
             Data::Opaque(data) => {
-                let point = Subslice::new(&data).read_point()?;
+                let point = SliceReader::parse(&data, |mut r| r.read_point())?;
                 Ok(Commitment::Closed(point))
             }
             Data::Witness(witness) => match witness {

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -250,7 +250,7 @@ impl Data {
     pub fn to_predicate(self) -> Result<Predicate, VMError> {
         match self {
             Data::Opaque(data) => {
-                let point = SliceReader::parse(&data, |mut r| r.read_point())?;
+                let point = SliceReader::parse(&data, |r| r.read_point())?;
                 Ok(Predicate::opaque(point))
             }
             Data::Witness(witness) => match witness {
@@ -263,7 +263,7 @@ impl Data {
     pub fn to_commitment(self) -> Result<Commitment, VMError> {
         match self {
             Data::Opaque(data) => {
-                let point = SliceReader::parse(&data, |mut r| r.read_point())?;
+                let point = SliceReader::parse(&data, |r| r.read_point())?;
                 Ok(Commitment::Closed(point))
             }
             Data::Witness(witness) => match witness {

--- a/zkvm/src/verifier.rs
+++ b/zkvm/src/verifier.rs
@@ -55,12 +55,12 @@ impl<'a, 'b> Delegate<r1cs::Verifier<'a, 'b>> for Verifier<'a, 'b> {
         &mut self,
         run: &mut Self::RunType,
     ) -> Result<Option<Instruction>, VMError> {
+        if run.offset == run.program.len() {
+            return Ok(None);
+        }
         let (instr, remainder) = SliceReader::parse(&run.program[run.offset..], |r| {
             Ok((Instruction::parse(r)?, r.skip_trailing_bytes()))
         })?;
-        if remainder == 0 {
-            return Ok(None);
-        }
         run.offset = run.program.len() - remainder;
         Ok(Some(instr))
     }

--- a/zkvm/src/verifier.rs
+++ b/zkvm/src/verifier.rs
@@ -55,14 +55,13 @@ impl<'a, 'b> Delegate<r1cs::Verifier<'a, 'b>> for Verifier<'a, 'b> {
         &mut self,
         run: &mut Self::RunType,
     ) -> Result<Option<Instruction>, VMError> {
-        let mut program = SliceReader::new_with_range(&run.program, run.offset..run.program.len())?;
-
-        // Reached the end of the program - no more instructions to execute.
-        if program.len() == 0 {
+        let (instr, remainder) = SliceReader::parse(&run.program[run.offset..], |r| {
+            Ok((Instruction::parse(r)?, r.skip_trailing_bytes()))
+        })?;
+        if remainder == 0 {
             return Ok(None);
         }
-        let instr = Instruction::parse(&mut program)?;
-        run.offset = program.range().start;
+        run.offset = run.program.len() - remainder;
         Ok(Some(instr))
     }
 

--- a/zkvm/src/verifier.rs
+++ b/zkvm/src/verifier.rs
@@ -55,7 +55,7 @@ impl<'a, 'b> Delegate<r1cs::Verifier<'a, 'b>> for Verifier<'a, 'b> {
         &mut self,
         run: &mut Self::RunType,
     ) -> Result<Option<Instruction>, VMError> {
-        let mut program = Subslice::new_with_range(&run.program, run.offset..run.program.len())?;
+        let mut program = SliceReader::new_with_range(&run.program, run.offset..run.program.len())?;
 
         // Reached the end of the program - no more instructions to execute.
         if program.len() == 0 {

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -307,7 +307,7 @@ where
 
     fn r#const(&mut self) -> Result<(), VMError> {
         let data = self.pop_item()?.to_data()?.to_bytes();
-        let scalar = SliceReader::parse(&data, |mut r| r.read_scalar())?;
+        let scalar = SliceReader::parse(&data, |r| r.read_scalar())?;
         self.push_item(Expression::constant(scalar));
         Ok(())
     }

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -8,7 +8,7 @@ use std::iter::FromIterator;
 use std::ops::Neg;
 
 use crate::contract::{Contract, FrozenContract, FrozenItem, FrozenValue, PortableItem};
-use crate::encoding::Subslice;
+use crate::encoding::SliceReader;
 use crate::errors::VMError;
 use crate::ops::Instruction;
 use crate::point_ops::PointOp;
@@ -307,11 +307,7 @@ where
 
     fn r#const(&mut self) -> Result<(), VMError> {
         let data = self.pop_item()?.to_data()?.to_bytes();
-        let mut slice = Subslice::new(&data);
-        let scalar = slice.read_scalar()?;
-        if slice.len() != 0 {
-            return Err(VMError::FormatError);
-        }
+        let scalar = SliceReader::parse(&data, |mut r| r.read_scalar())?;
         self.push_item(Expression::constant(scalar));
         Ok(())
     }


### PR DESCRIPTION
Rename `Subslice` to `SliceReader` and change API for safer subslice parsing.

Fixes #80 