### PR TITLE
slidechain: delete processed exports

### DIFF
--- a/slidechain/export.go
+++ b/slidechain/export.go
@@ -120,6 +120,9 @@ func (c *Custodian) pegOutFromExports(ctx context.Context) {
 					log.Fatalf("updating export table: %s", err)
 				}
 			}
+			if peggedOut == pegOutFail {
+				log.Fatalf("peg-out failed for tx %s", txid)
+			}
 		}
 	}
 }

--- a/slidechain/export.go
+++ b/slidechain/export.go
@@ -116,6 +116,9 @@ func (c *Custodian) pegOutFromExports(ctx context.Context) {
 			} else {
 				peggedOut = pegOutOK
 			}
+			if peggedOut == pegOutFail {
+				log.Fatalf("pegging out tx: %s", err)
+			}
 			_, err = c.DB.ExecContext(ctx, `UPDATE exports SET pegged_out=$1 WHERE txid=$2`, peggedOut, txid)
 			if err != nil {
 				log.Fatalf("updating export table: %s", err)

--- a/slidechain/export.go
+++ b/slidechain/export.go
@@ -99,7 +99,7 @@ func (c *Custodian) pegOutFromExports(ctx context.Context) {
 			}
 
 			log.Printf("pegging out export %x: %d of %s to %s", txid, amounts[i], asset.String(), exporters[i])
-			// TODO(vniu): flag txs that fail with unretriable errors in the db
+
 			var peggedOut pegOutState
 			err = c.pegOut(ctx, exporter, asset, int64(amounts[i]), tempID, xdr.SequenceNumber(seqnums[i]))
 			if err != nil {
@@ -109,7 +109,7 @@ func (c *Custodian) pegOutFromExports(ctx context.Context) {
 					if err != nil {
 						log.Fatalf("getting error codes from failed submission of tx %s", txid)
 					}
-					if resultCodes.TransactionCode == xdr.TransactionResultCodeTxBadSeq.String() { // retriable error
+					if resultCodes.TransactionCode == xdr.TransactionResultCodeTxBadSeq.String() {
 						peggedOut = pegOutRetry
 					}
 				}

--- a/slidechain/schema.go
+++ b/slidechain/schema.go
@@ -29,8 +29,7 @@ CREATE TABLE IF NOT EXISTS exports (
   amount INTEGER NOT NULL,
   asset_xdr BLOB NOT NULL,
   temp TEXT NOT NULL,
-  seqnum INTEGER NOT NULL,
-  pegged_out INTEGER NOT NULL DEFAULT 0
+  seqnum INTEGER NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS custodian (

--- a/slidechain/schema.go
+++ b/slidechain/schema.go
@@ -30,7 +30,7 @@ CREATE TABLE IF NOT EXISTS exports (
   asset_xdr BLOB NOT NULL,
   temp TEXT NOT NULL,
   seqnum INTEGER NOT NULL,
-  exported INTEGER NOT NULL DEFAULT 0
+  pegged_out INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS custodian (


### PR DESCRIPTION
Deletes rows that have been successfully processed (either success or nonretriable failure) from the `exports` table. We now only process rows that have not been pegged yet or have failed with a retriable error.

https://trello.com/c/5awzmfR4

