### PR TITLE
slidechain: add peg-out struct

### DIFF
--- a/slidechain/cmd/peg/peg.go
+++ b/slidechain/cmd/peg/peg.go
@@ -163,7 +163,7 @@ func submitPrepegTx(tx *bc.Tx, slidechaind string) error {
 }
 
 func recordPeg(txid bc.Hash, assetXDR []byte, amount, expMS int64, pubkey ed25519.PublicKey, slidechaind string) error {
-	p := slidechain.Peg{
+	p := slidechain.PegIn{
 		Amount:      amount,
 		AssetXDR:    assetXDR,
 		RecipPubkey: pubkey,

--- a/slidechain/cmd/slidechaind/slidechaind.go
+++ b/slidechain/cmd/slidechaind/slidechaind.go
@@ -50,6 +50,6 @@ func main() {
 	http.Handle("/submit", c.S)
 	http.HandleFunc("/get", c.S.Get)
 	http.HandleFunc("/account", c.Account)
-	http.HandleFunc("/record", c.RecordPeg)
+	http.HandleFunc("/record", c.RecordPegIn)
 	http.Serve(listener, nil)
 }

--- a/slidechain/custodian.go
+++ b/slidechain/custodian.go
@@ -190,8 +190,8 @@ func (c *Custodian) Account(w http.ResponseWriter, req *http.Request) {
 // launch kicks off the Custodian's long-running goroutines
 // that stream txs, import, and export.
 func (c *Custodian) launch(ctx context.Context) {
-	go c.watchPegs(ctx)
-	go c.importFromPegs(ctx, nil)
+	go c.watchPegIns(ctx)
+	go c.importFromPegIns(ctx, nil)
 	go c.watchExports(ctx)
 	go c.pegOutFromExports(ctx)
 }

--- a/slidechain/import.go
+++ b/slidechain/import.go
@@ -54,8 +54,8 @@ func (c *Custodian) buildImportTx(
 	return tx2, nil
 }
 
-func (c *Custodian) importFromPegs(ctx context.Context, ready chan struct{}) {
-	defer log.Print("importFromPegs exiting")
+func (c *Custodian) importFromPegIns(ctx context.Context, ready chan struct{}) {
+	defer log.Print("importFromPegIns exiting")
 
 	ch := make(chan struct{})
 	go func() {

--- a/slidechain/record.go
+++ b/slidechain/record.go
@@ -11,23 +11,23 @@ import (
 	"github.com/interstellar/slingshot/slidechain/net"
 )
 
-// Peg contains the fields for a peg-in transaction in the database.
-type Peg struct {
+// PegIn contains the fields for a peg-in transaction in the database.
+type PegIn struct {
 	Amount      int64  `json:"amount"`
 	AssetXDR    []byte `json:"asset_xdr"`
 	RecipPubkey []byte `json:"recip_pubkey"`
 	ExpMS       int64  `json:"exp_ms"`
 }
 
-// RecordPeg records a peg-in transaction in the database.
+// RecordPegIn records a peg-in transaction in the database.
 // TODO(debnil): Make record RPC do pre-peg tx submission as well, instead of requiring a separate server round-trip first.
-func (c *Custodian) RecordPeg(w http.ResponseWriter, req *http.Request) {
+func (c *Custodian) RecordPegIn(w http.ResponseWriter, req *http.Request) {
 	data, err := ioutil.ReadAll(req.Body)
 	if err != nil {
 		net.Errorf(w, http.StatusInternalServerError, "sending response: %s", err)
 		return
 	}
-	var p Peg
+	var p PegIn
 	err = json.Unmarshal(data, &p)
 	if err != nil {
 		net.Errorf(w, http.StatusInternalServerError, "sending response: %s", err)
@@ -35,7 +35,7 @@ func (c *Custodian) RecordPeg(w http.ResponseWriter, req *http.Request) {
 	}
 	nonceHash := UniqueNonceHash(c.InitBlockHash.Bytes(), p.ExpMS)
 	ctx := req.Context()
-	err = c.insertPeg(ctx, nonceHash[:], p.RecipPubkey, p.ExpMS)
+	err = c.insertPegIn(ctx, nonceHash[:], p.RecipPubkey, p.ExpMS)
 	if err != nil {
 		net.Errorf(w, http.StatusInternalServerError, "sending response: %s", err)
 		return
@@ -44,7 +44,7 @@ func (c *Custodian) RecordPeg(w http.ResponseWriter, req *http.Request) {
 	return
 }
 
-func (c *Custodian) insertPeg(ctx context.Context, nonceHash, recip []byte, expMS int64) error {
+func (c *Custodian) insertPegIn(ctx context.Context, nonceHash, recip []byte, expMS int64) error {
 	const q = `INSERT INTO pegs
 		(nonce_hash, recipient_pubkey, nonce_expms)
 		VALUES ($1, $2, $3)`

--- a/slidechain/slidechain_test.go
+++ b/slidechain/slidechain_test.go
@@ -239,7 +239,7 @@ func TestImport(t *testing.T) {
 			}
 			log.Println("pre-peg-in tx hit the txvm chain...")
 			ready := make(chan struct{})
-			go c.importFromPegs(ctx, ready)
+			go c.importFromPegIns(ctx, ready)
 			<-ready
 			nonceHash := UniqueNonceHash(c.InitBlockHash.Bytes(), expMS)
 			_, err = db.Exec("INSERT INTO pegs (nonce_hash, amount, asset_xdr, recipient_pubkey, nonce_expms, stellar_tx) VALUES ($1, 1, $2, $3, $4, 1)", nonceHash[:], assetXDR, testRecipPubKey, expMS)

--- a/slidechain/slidechain_test.go
+++ b/slidechain/slidechain_test.go
@@ -334,7 +334,7 @@ func TestEndToEnd(t *testing.T) {
 			t.Fatal("unsuccessfully waited on pre-peg-in tx hitting txvm")
 		}
 		uniqueNonceHash := UniqueNonceHash(c.InitBlockHash.Bytes(), expMS)
-		err = c.insertPeg(ctx, uniqueNonceHash[:], exporterPubKeyBytes[:], expMS)
+		err = c.insertPegIn(ctx, uniqueNonceHash[:], exporterPubKeyBytes[:], expMS)
 		if err != nil {
 			t.Fatal("could not record peg")
 		}

--- a/slidechain/watch.go
+++ b/slidechain/watch.go
@@ -16,8 +16,8 @@ import (
 )
 
 // Runs as a goroutine until ctx is canceled.
-func (c *Custodian) watchPegs(ctx context.Context) {
-	defer log.Println("watchPegs exiting")
+func (c *Custodian) watchPegIns(ctx context.Context) {
+	defer log.Println("watchPegIns exiting")
 	backoff := i10rnet.Backoff{Base: 100 * time.Millisecond}
 
 	var cur horizon.Cursor

--- a/slidechain/watch.go
+++ b/slidechain/watch.go
@@ -133,12 +133,7 @@ func (c *Custodian) watchExports(ctx context.Context) {
 				if infoItem[0].(txvm.Bytes)[0] != txvm.LogCode {
 					continue
 				}
-				var info struct {
-					AssetXDR []byte `json:"asset"`
-					Temp     string `json:"temp"`
-					Seqnum   int64  `json:"seqnum"`
-					Exporter string `json:"exporter"`
-				}
+				var info pegOut
 				err := json.Unmarshal(infoItem[2].(txvm.Bytes), &info)
 				if err != nil {
 					continue


### PR DESCRIPTION
Adds a peg-out `struct`, in lieu of creating very similar but different `struct`s meant to hold information about a peg-out. Also renames several functions to refer specifically to peg-ins to avoid confusion.