### PR TITLE
slidechain: test different input and export amounts

### DIFF
--- a/slidechain/export.go
+++ b/slidechain/export.go
@@ -355,7 +355,7 @@ func BuildExportTx(ctx context.Context, asset xdr.Asset, amount, inputAmt int64,
 // {"R", ...}
 // {"L", ...}
 // {"F", ...}
-func IsExportTx(tx *bc.Tx, asset xdr.Asset, inputAmt int64, temp, exporter string, seqnum int64) bool {
+func IsExportTx(tx *bc.Tx, asset xdr.Asset, exportAmt int64, temp, exporter string, seqnum int64) bool {
 	// The export transaction when we export the full input amount has seven operations, and when we export
 	// part of the input and output the rest back to the exporter, it has ten operations
 	if len(tx.Log) != 7 && len(tx.Log) != 10 {
@@ -370,7 +370,7 @@ func IsExportTx(tx *bc.Tx, asset xdr.Asset, inputAmt int64, temp, exporter strin
 	if tx.Log[2][0].(txvm.Bytes)[0] != txvm.RetireCode {
 		return false
 	}
-	if int64(tx.Log[2][2].(txvm.Int)) != inputAmt {
+	if int64(tx.Log[2][2].(txvm.Int)) != exportAmt {
 		return false
 	}
 	assetBytes, err := asset.MarshalBinary()

--- a/slidechain/slidechain_test.go
+++ b/slidechain/slidechain_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"database/sql"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -412,7 +411,7 @@ func TestEndToEnd(t *testing.T) {
 			}
 			defer resp.Body.Close()
 			if resp.StatusCode/100 != 2 {
-				t.Fatalf("status code %d from POST /submit", resp.StatusCode)
+				t.Fatalf("status code %d from POST /submit?wait=1", resp.StatusCode)
 			}
 
 			// Check for successful retirement.
@@ -511,71 +510,6 @@ func isImportTx(tx *bc.Tx, amount int64, assetXDR []byte, recipPubKey ed25519.Pu
 		return false
 	}
 	// No need to test tx.Log[4], it has to be a finalize entry.
-	return true
-}
-
-// Expected log is:
-// For an export that fully consumes the input:
-// {"I", ...}
-// {"L", ...}
-// {"X", vm seed, inputAmount, asset id, anchor}
-// {"L", vm seed, refdata}
-// {"R", ...} timerange
-// {"L", ...}
-// {"F", ...}
-//
-// For an export that partially consumes the input:
-// {"I", ...}
-// {"L", ...}
-// {"X", vm seed, inputAmount, asset id, anchor}
-// {"L", vm seed, refdata}
-// {"L", ...}
-// {"L", ...}
-// {"O", caller, outputid}
-// {"R", ...}
-// {"L", ...}
-// {"F", ...}
-func isExportTx(tx *bc.Tx, asset xdr.Asset, inputAmt int64, temp, exporter string, seqnum int64) bool {
-	// The export transaction when we export the full input amount has seven operations, and when we export
-	// part of the input and output the rest back to the exporter, it has ten operations
-	if len(tx.Log) != 7 && len(tx.Log) != 10 {
-		return false
-	}
-	if tx.Log[0][0].(txvm.Bytes)[0] != txvm.InputCode {
-		return false
-	}
-	if tx.Log[1][0].(txvm.Bytes)[0] != txvm.LogCode {
-		return false
-	}
-	if tx.Log[2][0].(txvm.Bytes)[0] != txvm.RetireCode {
-		return false
-	}
-	if int64(tx.Log[2][2].(txvm.Int)) != inputAmt {
-		return false
-	}
-	assetBytes, err := asset.MarshalBinary()
-	if err != nil {
-		return false
-	}
-	wantAssetID := txvm.AssetID(importIssuanceSeed[:], assetBytes)
-	if !bytes.Equal(wantAssetID[:], tx.Log[2][3].(txvm.Bytes)) {
-		return false
-	}
-	if tx.Log[3][0].(txvm.Bytes)[0] != txvm.LogCode {
-		return false
-	}
-	ref := pegOut{
-		assetBytes,
-		temp,
-		seqnum,
-		exporter,
-	}
-	refdata, err := json.Marshal(ref)
-	if !bytes.Equal(refdata, tx.Log[3][2].(txvm.Bytes)) {
-		return false
-	}
-	// Beyond this, the two transactions diverge but must either finalize
-	// or output the remaining unconsumed input
 	return true
 }
 

--- a/slidechain/slidechain_test.go
+++ b/slidechain/slidechain_test.go
@@ -275,34 +275,34 @@ func TestEndToEnd(t *testing.T) {
 		{5 * xlm.Lumen, 5 * xlm.Lumen},
 		{5 * xlm.Lumen, 3 * xlm.Lumen},
 	}
-	for _, tt := range tests {
-		withTestServer(ctx, t, func(ctx context.Context, db *sql.DB, s *submitter, sv *httptest.Server, ch *protocol.Chain) {
-			hclient := &horizon.Client{
-				URL:  "https://horizon-testnet.stellar.org",
-				HTTP: new(http.Client),
-			}
-			root, err := hclient.Root()
-			if err != nil {
-				t.Fatalf("error getting horizon client root: %s", err)
-			}
-			accountID, seed, err := custodianAccount(ctx, db, hclient)
-			if err != nil {
-				t.Fatalf("error creating custodian account: %s", err)
-			}
-			c := &Custodian{
-				seed:          seed,
-				AccountID:     *accountID,
-				S:             s,
-				DB:            db,
-				hclient:       hclient,
-				InitBlockHash: ch.InitialBlockHash,
-				imports:       sync.NewCond(new(sync.Mutex)),
-				exports:       sync.NewCond(new(sync.Mutex)),
-				network:       root.NetworkPassphrase,
-				privkey:       custodianPrv,
-			}
-			c.launch(ctx)
+	withTestServer(ctx, t, func(ctx context.Context, db *sql.DB, s *submitter, sv *httptest.Server, ch *protocol.Chain) {
+		hclient := &horizon.Client{
+			URL:  "https://horizon-testnet.stellar.org",
+			HTTP: new(http.Client),
+		}
+		root, err := hclient.Root()
+		if err != nil {
+			t.Fatalf("error getting horizon client root: %s", err)
+		}
+		accountID, seed, err := custodianAccount(ctx, db, hclient)
+		if err != nil {
+			t.Fatalf("error creating custodian account: %s", err)
+		}
+		c := &Custodian{
+			seed:          seed,
+			AccountID:     *accountID,
+			S:             s,
+			DB:            db,
+			hclient:       hclient,
+			InitBlockHash: ch.InitialBlockHash,
+			imports:       sync.NewCond(new(sync.Mutex)),
+			exports:       sync.NewCond(new(sync.Mutex)),
+			network:       root.NetworkPassphrase,
+			privkey:       custodianPrv,
+		}
+		c.launch(ctx)
 
+		for _, tt := range tests {
 			// Prepare Stellar account to peg-in funds and txvm account to receive funds.
 			inputAmount := tt.inputAmount
 			exportAmount := tt.exportAmount
@@ -479,8 +479,8 @@ func TestEndToEnd(t *testing.T) {
 				t.Fatal("context timed out: no peg-out tx seen")
 			case <-retire:
 			}
-		})
-	}
+		}
+	})
 }
 
 // Expected log is:

--- a/slidechain/slidechain_test.go
+++ b/slidechain/slidechain_test.go
@@ -265,209 +265,222 @@ func TestImport(t *testing.T) {
 }
 
 func TestEndToEnd(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()
-	withTestServer(ctx, t, func(ctx context.Context, db *sql.DB, s *submitter, sv *httptest.Server, ch *protocol.Chain) {
-		hclient := &horizon.Client{
-			URL:  "https://horizon-testnet.stellar.org",
-			HTTP: new(http.Client),
-		}
-		root, err := hclient.Root()
-		if err != nil {
-			t.Fatalf("error getting horizon client root: %s", err)
-		}
-		accountID, seed, err := custodianAccount(ctx, db, hclient)
-		if err != nil {
-			t.Fatalf("error creating custodian account: %s", err)
-		}
-		c := &Custodian{
-			seed:          seed,
-			AccountID:     *accountID,
-			S:             s,
-			DB:            db,
-			hclient:       hclient,
-			InitBlockHash: ch.InitialBlockHash,
-			imports:       sync.NewCond(new(sync.Mutex)),
-			exports:       sync.NewCond(new(sync.Mutex)),
-			network:       root.NetworkPassphrase,
-			privkey:       custodianPrv,
-		}
-		c.launch(ctx)
-
-		// Prepare Stellar account to peg-in funds and txvm account to receive funds.
-		amount := 5 * xlm.Lumen
-		exporterPub, exporterPrv, err := ed25519.GenerateKey(nil)
-		if err != nil {
-			t.Fatalf("error generating txvm recipient keypair: %s", err)
-		}
-		var exporterSeed [32]byte
-		copy(exporterSeed[:], exporterPrv)
-		exporter, err := keypair.FromRawSeed(exporterSeed)
-		err = stellar.FundAccount(exporter.Address())
-		if err != nil {
-			t.Fatalf("error funding account %s: %s", exporter.Address(), err)
-		}
-
-		var exporterPubKeyBytes [32]byte
-		copy(exporterPubKeyBytes[:], exporterPub)
-
-		// TODO(debnil): Test non-native asset types.
-		native := xdr.Asset{
-			Type: xdr.AssetTypeAssetTypeNative,
-		}
-		nativeAssetBytes, err := native.MarshalBinary()
-		if err != nil {
-			t.Fatalf("error marshaling native asset to xdr: %s", err)
-		}
-		expMS := int64(bc.Millis(time.Now().Add(10 * time.Minute)))
-		// Build, submit, and wait on pre-peg-in TxVM tx.
-		prepegTx, err := BuildPrepegTx(c.InitBlockHash.Bytes(), nativeAssetBytes, exporterPubKeyBytes[:], int64(amount), expMS)
-		if err != nil {
-			t.Fatal("could not build pre-peg-in tx")
-		}
-		r, err := c.S.submitTx(ctx, prepegTx)
-		if err != nil {
-			t.Fatal("could not submit pre-peg-in tx")
-		}
-		err = c.S.waitOnTx(ctx, prepegTx.ID, r)
-		if err != nil {
-			t.Fatal("unsuccessfully waited on pre-peg-in tx hitting txvm")
-		}
-		uniqueNonceHash := UniqueNonceHash(c.InitBlockHash.Bytes(), expMS)
-		err = c.insertPegIn(ctx, uniqueNonceHash[:], exporterPubKeyBytes[:], expMS)
-		if err != nil {
-			t.Fatal("could not record peg")
-		}
-
-		// Build transaction to peg-in funds.
-		pegInTx, err := stellar.BuildPegInTx(exporter.Address(), uniqueNonceHash, amount.HorizonString(), "", "", c.AccountID.Address(), hclient)
-		if err != nil {
-			t.Fatalf("error building peg-in tx: %s", err)
-		}
-		succ, err := stellar.SignAndSubmitTx(hclient, pegInTx, exporter.Seed())
-		if err != nil {
-			t.Fatalf("error signing and submitting tx: %s", err)
-		}
-		t.Logf("successfully submitted peg-in tx: id %s, ledger %d", succ.Hash, succ.Ledger)
-
-		// Check to verify import.
-		var anchor []byte
-		found := false
-		for {
-			item, ok := r.Read(ctx)
-			if !ok {
-				t.Fatal("cannot read a block")
+	// TODO(debnil): Test non-native assets.
+	var tests = []struct {
+		inputAmount  xlm.Amount
+		exportAmount xlm.Amount
+	}{
+		{5 * xlm.Lumen, 5 * xlm.Lumen},
+		{5 * xlm.Lumen, 3 * xlm.Lumen},
+	}
+	for _, tt := range tests {
+		withTestServer(ctx, t, func(ctx context.Context, db *sql.DB, s *submitter, sv *httptest.Server, ch *protocol.Chain) {
+			hclient := &horizon.Client{
+				URL:  "https://horizon-testnet.stellar.org",
+				HTTP: new(http.Client),
 			}
-			block := item.(*bc.Block)
-			for _, tx := range block.Transactions {
-				if isImportTx(tx, int64(amount), nativeAssetBytes, exporterPub) {
-					t.Logf("found import tx %x", tx.Program)
-					found = true
-					txresult := txresult.New(tx)
-					anchor = txresult.Outputs[0].Value.Anchor
-					break
-				}
-			}
-			if found == true {
-				break
-			}
-		}
-		t.Log("submitting pre-export tx...")
-		temp, seqnum, err := SubmitPreExportTx(hclient, exporter, c.AccountID.Address(), native, int64(amount))
-		if err != nil {
-			t.Fatalf("pre-submit tx error: %s", err)
-		}
-		t.Log("building export tx...")
-		exportTx, err := BuildExportTx(ctx, native, int64(amount), int64(amount), temp, anchor, exporterPrv, seqnum)
-		if err != nil {
-			t.Fatalf("error building retirement tx %s", err)
-		}
-		txbits, err := proto.Marshal(&exportTx.RawTx)
-		if err != nil {
-			t.Fatal(err)
-		}
-		resp, err := http.Post(sv.URL+"/submit", "application/octet-stream", bytes.NewReader(txbits))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if resp.StatusCode/100 != 2 {
-			t.Fatalf("status code %d from POST /submit", resp.StatusCode)
-		}
-		t.Log("checking for retirement tx on txvm...")
-
-		found = false
-		for {
-			item, ok := r.Read(ctx)
-			if !ok {
-				t.Fatal("cannot read a block")
-			}
-			block := item.(*bc.Block)
-			for _, tx := range block.Transactions {
-				// Look for export transaction.
-				if IsExportTx(tx, native, int64(amount), temp, exporter.Address(), int64(seqnum)) {
-					t.Logf("found export tx %x", tx.Program)
-					found = true
-					break
-				}
-			}
-			if found == true {
-				break
-			}
-		}
-		t.Log("checking for successful retirement...")
-
-		// Check for successful retirement.
-		retire := make(chan struct{})
-		go func() {
-			var cur horizon.Cursor
-			err := c.hclient.StreamTransactions(ctx, exporter.Address(), &cur, func(tx horizon.Transaction) {
-				t.Logf("received tx: %s", tx.EnvelopeXdr)
-				var env xdr.TransactionEnvelope
-				err := xdr.SafeUnmarshalBase64(tx.EnvelopeXdr, &env)
-				if err != nil {
-					t.Fatal(err)
-				}
-				if env.Tx.SourceAccount.Address() != temp {
-					t.Log("source accounts don't match, skipping...")
-					return
-				}
-				defer close(retire)
-				if len(env.Tx.Operations) != 2 {
-					t.Fatalf("too many operations got %d, want 2", len(env.Tx.Operations))
-				}
-				op := env.Tx.Operations[0]
-				if op.Body.Type != xdr.OperationTypeAccountMerge {
-					t.Fatalf("wrong operation type: got %s, want %s", op.Body.Type, xdr.OperationTypeAccountMerge)
-				}
-				if op.Body.Destination.Address() != exporter.Address() {
-					t.Fatalf("wrong account merge destination: got %s, want %s", op.Body.Destination.Address(), exporter.Address())
-				}
-				op = env.Tx.Operations[1]
-				if op.Body.Type != xdr.OperationTypePayment {
-					t.Fatalf("wrong operation type: got %s, want %s", op.Body.Type, xdr.OperationTypePayment)
-				}
-				paymentOp := op.Body.PaymentOp
-				if paymentOp.Destination.Address() != exporter.Address() {
-					t.Fatalf("incorrect payment destination got %s, want %s", paymentOp.Destination.Address(), exporter.Address())
-				}
-				if paymentOp.Amount != xdr.Int64(amount) {
-					t.Fatalf("got incorrect payment amount %d, want %d", paymentOp.Amount, amount)
-				}
-				if paymentOp.Asset.Type != xdr.AssetTypeAssetTypeNative {
-					t.Fatalf("got incorrect payment asset %s, want lumens", paymentOp.Asset.String())
-				}
-			})
+			root, err := hclient.Root()
 			if err != nil {
-				t.Fatalf("error streaming from Horizon: %s", err)
+				t.Fatalf("error getting horizon client root: %s", err)
 			}
-		}()
+			accountID, seed, err := custodianAccount(ctx, db, hclient)
+			if err != nil {
+				t.Fatalf("error creating custodian account: %s", err)
+			}
+			c := &Custodian{
+				seed:          seed,
+				AccountID:     *accountID,
+				S:             s,
+				DB:            db,
+				hclient:       hclient,
+				InitBlockHash: ch.InitialBlockHash,
+				imports:       sync.NewCond(new(sync.Mutex)),
+				exports:       sync.NewCond(new(sync.Mutex)),
+				network:       root.NetworkPassphrase,
+				privkey:       custodianPrv,
+			}
+			c.launch(ctx)
 
-		select {
-		case <-ctx.Done():
-			t.Fatal("context timed out: no peg-out tx seen")
-		case <-retire:
-		}
-	})
+			// Prepare Stellar account to peg-in funds and txvm account to receive funds.
+			inputAmount := tt.inputAmount
+			exportAmount := tt.exportAmount
+			exporterPub, exporterPrv, err := ed25519.GenerateKey(nil)
+			if err != nil {
+				t.Fatalf("error generating txvm recipient keypair: %s", err)
+			}
+			var exporterSeed [32]byte
+			copy(exporterSeed[:], exporterPrv)
+			exporter, err := keypair.FromRawSeed(exporterSeed)
+			err = stellar.FundAccount(exporter.Address())
+			if err != nil {
+				t.Fatalf("error funding account %s: %s", exporter.Address(), err)
+			}
+
+			var exporterPubKeyBytes [32]byte
+			copy(exporterPubKeyBytes[:], exporterPub)
+
+			native := xdr.Asset{
+				Type: xdr.AssetTypeAssetTypeNative,
+			}
+			nativeAssetBytes, err := native.MarshalBinary()
+			if err != nil {
+				t.Fatalf("error marshaling native asset to xdr: %s", err)
+			}
+			expMS := int64(bc.Millis(time.Now().Add(10 * time.Minute)))
+			// Build, submit, and wait on pre-peg-in TxVM tx.
+			prepegTx, err := BuildPrepegTx(c.InitBlockHash.Bytes(), nativeAssetBytes, exporterPubKeyBytes[:], int64(inputAmount), expMS)
+			if err != nil {
+				t.Fatal("could not build pre-peg-in tx")
+			}
+			r, err := c.S.submitTx(ctx, prepegTx)
+			if err != nil {
+				t.Fatal("could not submit pre-peg-in tx")
+			}
+			err = c.S.waitOnTx(ctx, prepegTx.ID, r)
+			if err != nil {
+				t.Fatal("unsuccessfully waited on pre-peg-in tx hitting txvm")
+			}
+			uniqueNonceHash := UniqueNonceHash(c.InitBlockHash.Bytes(), expMS)
+			err = c.insertPegIn(ctx, uniqueNonceHash[:], exporterPubKeyBytes[:], expMS)
+			if err != nil {
+				t.Fatal("could not record peg")
+			}
+
+			// Build transaction to peg-in funds.
+			pegInTx, err := stellar.BuildPegInTx(exporter.Address(), uniqueNonceHash, inputAmount.HorizonString(), "", "", c.AccountID.Address(), hclient)
+			if err != nil {
+				t.Fatalf("error building peg-in tx: %s", err)
+			}
+			succ, err := stellar.SignAndSubmitTx(hclient, pegInTx, exporter.Seed())
+			if err != nil {
+				t.Fatalf("error signing and submitting tx: %s", err)
+			}
+			t.Logf("successfully submitted peg-in tx: id %s, ledger %d", succ.Hash, succ.Ledger)
+
+			// Check to verify import.
+			var anchor []byte
+			found := false
+			for {
+				item, ok := r.Read(ctx)
+				if !ok {
+					t.Fatal("cannot read a block")
+				}
+				block := item.(*bc.Block)
+				for _, tx := range block.Transactions {
+					if isImportTx(tx, int64(inputAmount), nativeAssetBytes, exporterPub) {
+						t.Logf("found import tx %x", tx.Program)
+						found = true
+						txresult := txresult.New(tx)
+						anchor = txresult.Outputs[0].Value.Anchor
+						break
+					}
+				}
+				if found == true {
+					break
+				}
+			}
+			t.Log("submitting pre-export tx...")
+			temp, seqnum, err := SubmitPreExportTx(hclient, exporter, c.AccountID.Address(), native, int64(exportAmount))
+			if err != nil {
+				t.Fatalf("pre-submit tx error: %s", err)
+			}
+			t.Log("building export tx...")
+			exportTx, err := BuildExportTx(ctx, native, int64(exportAmount), int64(inputAmount), temp, anchor, exporterPrv, seqnum)
+			if err != nil {
+				t.Fatalf("error building retirement tx %s", err)
+			}
+			txbits, err := proto.Marshal(&exportTx.RawTx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			resp, err := http.Post(sv.URL+"/submit", "application/octet-stream", bytes.NewReader(txbits))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if resp.StatusCode/100 != 2 {
+				t.Fatalf("status code %d from POST /submit", resp.StatusCode)
+			}
+			t.Log("checking for retirement tx on txvm...")
+			log.Print("checking for retirement tx on txvm...")
+
+			found = false
+			for {
+				item, ok := r.Read(ctx)
+				if !ok {
+					t.Fatal("cannot read a block")
+				}
+				block := item.(*bc.Block)
+				for _, tx := range block.Transactions {
+					// Look for export transaction.
+					if IsExportTx(tx, native, int64(exportAmount), temp, exporter.Address(), int64(seqnum)) {
+						t.Logf("found export tx %x", tx.Program)
+						log.Printf("found export tx %x", tx.Program)
+						found = true
+						break
+					}
+				}
+				if found == true {
+					break
+				}
+			}
+			t.Log("checking for successful retirement...")
+			log.Print("checking for successful retirement...")
+
+			// Check for successful retirement.
+			retire := make(chan struct{})
+			go func() {
+				var cur horizon.Cursor
+				err := c.hclient.StreamTransactions(ctx, exporter.Address(), &cur, func(tx horizon.Transaction) {
+					t.Logf("received tx: %s", tx.EnvelopeXdr)
+					var env xdr.TransactionEnvelope
+					err := xdr.SafeUnmarshalBase64(tx.EnvelopeXdr, &env)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if env.Tx.SourceAccount.Address() != temp {
+						t.Log("source accounts don't match, skipping...")
+						return
+					}
+					defer close(retire)
+					if len(env.Tx.Operations) != 2 {
+						t.Fatalf("too many operations got %d, want 2", len(env.Tx.Operations))
+					}
+					op := env.Tx.Operations[0]
+					if op.Body.Type != xdr.OperationTypeAccountMerge {
+						t.Fatalf("wrong operation type: got %s, want %s", op.Body.Type, xdr.OperationTypeAccountMerge)
+					}
+					if op.Body.Destination.Address() != exporter.Address() {
+						t.Fatalf("wrong account merge destination: got %s, want %s", op.Body.Destination.Address(), exporter.Address())
+					}
+					op = env.Tx.Operations[1]
+					if op.Body.Type != xdr.OperationTypePayment {
+						t.Fatalf("wrong operation type: got %s, want %s", op.Body.Type, xdr.OperationTypePayment)
+					}
+					paymentOp := op.Body.PaymentOp
+					if paymentOp.Destination.Address() != exporter.Address() {
+						t.Fatalf("incorrect payment destination got %s, want %s", paymentOp.Destination.Address(), exporter.Address())
+					}
+					if paymentOp.Amount != xdr.Int64(exportAmount) {
+						t.Fatalf("got incorrect payment amount %d, want %d", paymentOp.Amount, exportAmount)
+					}
+					if paymentOp.Asset.Type != xdr.AssetTypeAssetTypeNative {
+						t.Fatalf("got incorrect payment asset %s, want lumens", paymentOp.Asset.String())
+					}
+				})
+				if err != nil {
+					t.Fatalf("error streaming from Horizon: %s", err)
+				}
+			}()
+
+			select {
+			case <-ctx.Done():
+				t.Fatal("context timed out: no peg-out tx seen")
+			case <-retire:
+			}
+		})
+	}
 }
 
 // Expected log is:


### PR DESCRIPTION
Tests different amounts for input and export in the end-to-end test. Simplifies check for export tx to use `wait` logic in submission, instead of a hand-rolled function.