### PR TITLE
slidechain: clean up export cmd

### DIFF
--- a/slidechain/cmd/export/export.go
+++ b/slidechain/cmd/export/export.go
@@ -109,13 +109,13 @@ func main() {
 	if err != nil {
 		log.Fatalf("error unmarshaling custodian account id: %s", err)
 	}
-	temp, seqnum, err := slidechain.SubmitPreExportTx(hclient, kp, custodian.Address(), asset, exportAmount)
+	tempAddr, seqnum, err := slidechain.SubmitPreExportTx(hclient, kp, custodian.Address(), asset, exportAmount)
 	if err != nil {
 		log.Fatalf("error submitting pre-export tx: %s", err)
 	}
 
 	// Export funds from slidechain
-	tx, err := slidechain.BuildExportTx(ctx, asset, exportAmount, inputAmount, temp, mustDecodeHex(*anchor), mustDecodeHex(*prv), seqnum)
+	tx, err := slidechain.BuildExportTx(ctx, asset, exportAmount, inputAmount, tempAddr, mustDecodeHex(*anchor), mustDecodeHex(*prv), seqnum)
 	if err != nil {
 		log.Fatalf("error building export tx: %s", err)
 	}

--- a/slidechain/cmd/export/export.go
+++ b/slidechain/cmd/export/export.go
@@ -6,14 +6,12 @@ import (
 	"encoding/hex"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
 
-	"github.com/chain/txvm/protocol/bc"
 	"github.com/golang/protobuf/proto"
 	"github.com/interstellar/slingshot/slidechain"
 	"github.com/interstellar/slingshot/slidechain/stellar"
@@ -91,7 +89,7 @@ func main() {
 
 	// Check that stellar account exists
 	var seed [32]byte
-	rawbytes := mustDecode(*prv)
+	rawbytes := mustDecodeHex(*prv)
 	copy(seed[:], rawbytes)
 	kp, err := keypair.FromRawSeed(seed)
 	hclient := horizon.DefaultTestNetClient
@@ -117,7 +115,7 @@ func main() {
 	}
 
 	// Export funds from slidechain
-	tx, err := slidechain.BuildExportTx(ctx, asset, exportAmount, inputAmount, temp, mustDecode(*anchor), mustDecode(*prv), seqnum)
+	tx, err := slidechain.BuildExportTx(ctx, asset, exportAmount, inputAmount, temp, mustDecodeHex(*anchor), mustDecodeHex(*prv), seqnum)
 	if err != nil {
 		log.Fatalf("error building export tx: %s", err)
 	}
@@ -126,73 +124,21 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// Get latest block height
-	resp, err = http.Get(*slidechaind + "/get?height=0")
-	if err != nil {
-		log.Fatalf("error getting latest block height: %s", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode/100 != 2 {
-		log.Fatalf("bad status code %d getting latest block height", resp.StatusCode)
-	}
-	block := new(bc.Block)
-	bits, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		log.Fatalf("error reading block from response body: %s", err)
-	}
-	err = block.FromBytes(bits)
-	if err != nil {
-		log.Fatalf("error unmarshaling block: %s", err)
-	}
-
-	resp, err = http.Post(*slidechaind+"/submit", "application/octet-stream", bytes.NewReader(txbits))
+	resp, err = http.Post(*slidechaind+"/submit?wait=1", "application/octet-stream", bytes.NewReader(txbits))
 	if err != nil {
 		log.Fatalf("error submitting tx to slidechaind: %s", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode/100 != 2 {
-		log.Fatalf("status code %d from POST /submit", resp.StatusCode)
+		log.Fatalf("bad status code %d from POST /submit?wait=1", resp.StatusCode)
 	}
 	log.Printf("successfully submitted export transaction: %x", tx.ID)
-
-	client := http.DefaultClient
-	for height := block.Height + 1; ; height++ {
-		req, err := http.NewRequest("GET", fmt.Sprintf(*slidechaind+"/get?height=%d", height), nil)
-		if err != nil {
-			log.Fatalf("error building request for latest block: %s", err)
-		}
-		req = req.WithContext(ctx)
-		resp, err = client.Do(req)
-		if err != nil {
-			log.Fatalf("error getting block at height %d: %s", height, err)
-		}
-		defer resp.Body.Close()
-		if resp.StatusCode/100 != 2 {
-			log.Fatalf("bad status code %d getting latest block height", resp.StatusCode)
-		}
-		b := new(bc.Block)
-		bits, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			log.Fatalf("error reading block from response body: %s", err)
-		}
-		err = b.FromBytes(bits)
-		if err != nil {
-			log.Fatalf("error unmarshaling block: %s", err)
-		}
-		for _, tx := range b.Transactions {
-			// Look for export transaction
-			if slidechain.IsExportTx(tx, asset, inputAmount, temp, kp.Address(), int64(seqnum)) {
-				log.Println("export tx included in txvm chain")
-				return
-			}
-		}
-	}
 }
 
-func mustDecode(src string) []byte {
+func mustDecodeHex(src string) []byte {
 	bytes, err := hex.DecodeString(src)
 	if err != nil {
-		log.Fatalf("error decoding %s: %s", src, err)
+		panic(fmt.Errorf("error decoding %s: %s", src, err))
 	}
 	return bytes
 }

--- a/slidechain/export.go
+++ b/slidechain/export.go
@@ -1,7 +1,6 @@
 package slidechain
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -330,71 +329,4 @@ func BuildExportTx(ctx context.Context, asset xdr.Asset, amount, inputAmt int64,
 		log.Printf("output: assetid %x amount %x anchor %x", output.AssetID.Bytes(), output.Amount, output.Anchor)
 	}
 	return tx, nil
-}
-
-// IsExportTx returns whether or not a txvm transaction matches the slidechain export tx format.
-//
-// Expected log is:
-// For an export that fully consumes the input:
-// {"I", ...}
-// {"L", ...}
-// {"X", vm seed, inputAmount, asset id, anchor}
-// {"L", vm seed, refdata}
-// {"R", ...} timerange
-// {"L", ...}
-// {"F", ...}
-//
-// For an export that partially consumes the input:
-// {"I", ...}
-// {"L", ...}
-// {"X", vm seed, inputAmount, asset id, anchor}
-// {"L", vm seed, refdata}
-// {"L", ...}
-// {"L", ...}
-// {"O", caller, outputid}
-// {"R", ...}
-// {"L", ...}
-// {"F", ...}
-func IsExportTx(tx *bc.Tx, asset xdr.Asset, inputAmt int64, temp, exporter string, seqnum int64) bool {
-	// The export transaction when we export the full input amount has seven operations, and when we export
-	// part of the input and output the rest back to the exporter, it has ten operations
-	if len(tx.Log) != 7 && len(tx.Log) != 10 {
-		return false
-	}
-	if tx.Log[0][0].(txvm.Bytes)[0] != txvm.InputCode {
-		return false
-	}
-	if tx.Log[1][0].(txvm.Bytes)[0] != txvm.LogCode {
-		return false
-	}
-	if tx.Log[2][0].(txvm.Bytes)[0] != txvm.RetireCode {
-		return false
-	}
-	if int64(tx.Log[2][2].(txvm.Int)) != inputAmt {
-		return false
-	}
-	assetBytes, err := asset.MarshalBinary()
-	if err != nil {
-		return false
-	}
-	wantAssetID := txvm.AssetID(importIssuanceSeed[:], assetBytes)
-	if !bytes.Equal(wantAssetID[:], tx.Log[2][3].(txvm.Bytes)) {
-		return false
-	}
-	if tx.Log[3][0].(txvm.Bytes)[0] != txvm.LogCode {
-		return false
-	}
-	ref := pegOut{
-		assetBytes,
-		temp,
-		seqnum,
-		exporter,
-	}
-	refdata, err := json.Marshal(ref)
-	if !bytes.Equal(refdata, tx.Log[3][2].(txvm.Bytes)) {
-		return false
-	}
-	// Beyond this, the two transactions diverge but must either finalize
-	// or output the remaining unconsumed input
-	return true
 }

--- a/slidechain/export.go
+++ b/slidechain/export.go
@@ -65,22 +65,22 @@ func (c *Custodian) pegOutFromExports(ctx context.Context) {
 		case <-ch:
 		}
 
-		const q = `SELECT txid, amount, asset_xdr, exporter, temp, seqnum FROM exports`
+		const q = `SELECT txid, amount, asset_xdr, exporter, temp_addr, seqnum FROM exports`
 
 		var (
 			txids     [][]byte
 			amounts   []int
 			assetXDRs [][]byte
 			exporters []string
-			temps     []string
+			tempAddrs []string
 			seqnums   []int
 		)
-		err := sqlutil.ForQueryRows(ctx, c.DB, q, func(txid []byte, amount int, assetXDR []byte, exporter string, temp string, seqnum int) {
+		err := sqlutil.ForQueryRows(ctx, c.DB, q, func(txid []byte, amount int, assetXDR []byte, exporter string, tempAddr string, seqnum int) {
 			txids = append(txids, txid)
 			amounts = append(amounts, amount)
 			assetXDRs = append(assetXDRs, assetXDR)
 			exporters = append(exporters, exporter)
-			temps = append(temps, temp)
+			tempAddrs = append(tempAddrs, tempAddr)
 			seqnums = append(seqnums, seqnum)
 		})
 		if err != nil {
@@ -93,9 +93,9 @@ func (c *Custodian) pegOutFromExports(ctx context.Context) {
 				log.Fatalf("unmarshalling asset from XDR %x: %s", assetXDRs[i], err)
 			}
 			var tempID xdr.AccountId
-			err = tempID.SetAddress(temps[i])
+			err = tempID.SetAddress(tempAddrs[i])
 			if err != nil {
-				log.Fatalf("setting temp address to %s: %s", temps[i], err)
+				log.Fatalf("setting temp address to %s: %s", tempAddrs[i], err)
 			}
 			var exporter xdr.AccountId
 			err = exporter.SetAddress(exporters[i])
@@ -133,8 +133,8 @@ func (c *Custodian) pegOutFromExports(ctx context.Context) {
 	}
 }
 
-func (c *Custodian) pegOut(ctx context.Context, exporter xdr.AccountId, asset xdr.Asset, amount int64, temp xdr.AccountId, seqnum xdr.SequenceNumber) error {
-	tx, err := buildPegOutTx(c.AccountID.Address(), exporter.Address(), temp.Address(), c.network, asset, amount, seqnum)
+func (c *Custodian) pegOut(ctx context.Context, exporter xdr.AccountId, asset xdr.Asset, amount int64, tempID xdr.AccountId, seqnum xdr.SequenceNumber) error {
+	tx, err := buildPegOutTx(c.AccountID.Address(), exporter.Address(), tempID.Address(), c.network, asset, amount, seqnum)
 	if err != nil {
 		return errors.Wrap(err, "building peg-out tx")
 	}
@@ -197,7 +197,7 @@ func createTempAccount(hclient horizon.ClientInterface, kp *keypair.Full) (*keyp
 	if err != nil {
 		return nil, 0, errors.Wrap(err, "getting Horizon root")
 	}
-	temp, err := keypair.Random()
+	tempKP, err := keypair.Random()
 	if err != nil {
 		return nil, 0, errors.Wrap(err, "generating random account")
 	}
@@ -208,7 +208,7 @@ func createTempAccount(hclient horizon.ClientInterface, kp *keypair.Full) (*keyp
 		b.BaseFee{Amount: baseFee},
 		b.CreateAccount(
 			b.NativeAmount{Amount: (2 * xlm.Lumen).HorizonString()},
-			b.Destination{AddressOrSeed: temp.Address()},
+			b.Destination{AddressOrSeed: tempKP.Address()},
 		),
 	)
 	if err != nil {
@@ -218,11 +218,11 @@ func createTempAccount(hclient horizon.ClientInterface, kp *keypair.Full) (*keyp
 	if err != nil {
 		return nil, 0, errors.Wrapf(err, "submitting temp account creation tx")
 	}
-	seqnum, err := hclient.SequenceForAccount(temp.Address())
+	seqnum, err := hclient.SequenceForAccount(tempKP.Address())
 	if err != nil {
-		return nil, 0, errors.Wrapf(err, "getting sequence number for temp account %s", temp.Address())
+		return nil, 0, errors.Wrapf(err, "getting sequence number for temp account %s", tempKP.Address())
 	}
-	return temp, seqnum, nil
+	return tempKP, seqnum, nil
 }
 
 // SubmitPreExportTx builds and submits the two pre-export transactions
@@ -231,19 +231,19 @@ func createTempAccount(hclient horizon.ClientInterface, kp *keypair.Full) (*keyp
 // The second transaction sets the signer on the temporary account
 // to be a preauth transaction, which merges the account and pays
 // out the pegged-out funds.
-// The function returns the temporary account ID and sequence number.
+// The function returns the temporary account address and sequence number.
 func SubmitPreExportTx(hclient horizon.ClientInterface, kp *keypair.Full, custodian string, asset xdr.Asset, amount int64) (string, xdr.SequenceNumber, error) {
 	root, err := hclient.Root()
 	if err != nil {
 		return "", 0, errors.Wrap(err, "getting Horizon root")
 	}
 
-	temp, seqnum, err := createTempAccount(hclient, kp)
+	tempKP, seqnum, err := createTempAccount(hclient, kp)
 	if err != nil {
 		return "", 0, errors.Wrap(err, "creating temp account")
 	}
 
-	preauthTx, err := buildPegOutTx(custodian, kp.Address(), temp.Address(), root.NetworkPassphrase, asset, amount, seqnum)
+	preauthTx, err := buildPegOutTx(custodian, kp.Address(), tempKP.Address(), root.NetworkPassphrase, asset, amount, seqnum)
 	if err != nil {
 		return "", 0, errors.Wrap(err, "building preauth tx")
 	}
@@ -262,7 +262,7 @@ func SubmitPreExportTx(hclient horizon.ClientInterface, kp *keypair.Full, custod
 		b.AutoSequence{SequenceProvider: hclient},
 		b.BaseFee{Amount: baseFee},
 		b.SetOptions(
-			b.SourceAccount{AddressOrSeed: temp.Address()},
+			b.SourceAccount{AddressOrSeed: tempKP.Address()},
 			b.MasterWeight(0),
 			b.SetThresholds(1, 1, 1),
 			b.AddSigner(hashStr, 1),
@@ -271,17 +271,17 @@ func SubmitPreExportTx(hclient horizon.ClientInterface, kp *keypair.Full, custod
 	if err != nil {
 		return "", 0, errors.Wrap(err, "building pre-export tx")
 	}
-	_, err = stellar.SignAndSubmitTx(hclient, tx, kp.Seed(), temp.Seed())
+	_, err = stellar.SignAndSubmitTx(hclient, tx, kp.Seed(), tempKP.Seed())
 	if err != nil {
 		return "", 0, errors.Wrap(err, "pre-exporttx")
 	}
-	return temp.Address(), seqnum, nil
+	return tempKP.Address(), seqnum, nil
 }
 
 // BuildExportTx builds a txvm retirement tx for an asset issued
 // onto slidechain. It will retire `amount` of the asset, and the
 // remaining input will be output back to the original account.
-func BuildExportTx(ctx context.Context, asset xdr.Asset, amount, inputAmt int64, temp string, anchor []byte, prv ed25519.PrivateKey, seqnum xdr.SequenceNumber) (*bc.Tx, error) {
+func BuildExportTx(ctx context.Context, asset xdr.Asset, amount, inputAmt int64, tempAddr string, anchor []byte, prv ed25519.PrivateKey, seqnum xdr.SequenceNumber) (*bc.Tx, error) {
 	if inputAmt < amount {
 		return nil, fmt.Errorf("cannot have input amount %d less than export amount %d", inputAmt, amount)
 	}
@@ -299,7 +299,7 @@ func BuildExportTx(ctx context.Context, asset xdr.Asset, amount, inputAmt int64,
 	pubkey := prv.Public().(ed25519.PublicKey)
 	ref := pegOut{
 		assetBytes,
-		temp,
+		tempAddr,
 		int64(seqnum),
 		kp.Address(),
 	}

--- a/slidechain/schema.go
+++ b/slidechain/schema.go
@@ -28,7 +28,7 @@ CREATE TABLE IF NOT EXISTS exports (
   exporter TEXT NOT NULL,
   amount INTEGER NOT NULL,
   asset_xdr BLOB NOT NULL,
-  temp TEXT NOT NULL,
+  temp_addr TEXT NOT NULL,
   seqnum INTEGER NOT NULL
 );
 

--- a/slidechain/slidechain_test.go
+++ b/slidechain/slidechain_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -404,7 +405,7 @@ func TestEndToEnd(t *testing.T) {
 			block := item.(*bc.Block)
 			for _, tx := range block.Transactions {
 				// Look for export transaction.
-				if IsExportTx(tx, native, int64(amount), temp, exporter.Address(), int64(seqnum)) {
+				if isExportTx(tx, native, int64(amount), temp, exporter.Address(), int64(seqnum)) {
 					t.Logf("found export tx %x", tx.Program)
 					found = true
 					break
@@ -510,6 +511,71 @@ func isImportTx(tx *bc.Tx, amount int64, assetXDR []byte, recipPubKey ed25519.Pu
 		return false
 	}
 	// No need to test tx.Log[4], it has to be a finalize entry.
+	return true
+}
+
+// Expected log is:
+// For an export that fully consumes the input:
+// {"I", ...}
+// {"L", ...}
+// {"X", vm seed, inputAmount, asset id, anchor}
+// {"L", vm seed, refdata}
+// {"R", ...} timerange
+// {"L", ...}
+// {"F", ...}
+//
+// For an export that partially consumes the input:
+// {"I", ...}
+// {"L", ...}
+// {"X", vm seed, inputAmount, asset id, anchor}
+// {"L", vm seed, refdata}
+// {"L", ...}
+// {"L", ...}
+// {"O", caller, outputid}
+// {"R", ...}
+// {"L", ...}
+// {"F", ...}
+func isExportTx(tx *bc.Tx, asset xdr.Asset, inputAmt int64, temp, exporter string, seqnum int64) bool {
+	// The export transaction when we export the full input amount has seven operations, and when we export
+	// part of the input and output the rest back to the exporter, it has ten operations
+	if len(tx.Log) != 7 && len(tx.Log) != 10 {
+		return false
+	}
+	if tx.Log[0][0].(txvm.Bytes)[0] != txvm.InputCode {
+		return false
+	}
+	if tx.Log[1][0].(txvm.Bytes)[0] != txvm.LogCode {
+		return false
+	}
+	if tx.Log[2][0].(txvm.Bytes)[0] != txvm.RetireCode {
+		return false
+	}
+	if int64(tx.Log[2][2].(txvm.Int)) != inputAmt {
+		return false
+	}
+	assetBytes, err := asset.MarshalBinary()
+	if err != nil {
+		return false
+	}
+	wantAssetID := txvm.AssetID(importIssuanceSeed[:], assetBytes)
+	if !bytes.Equal(wantAssetID[:], tx.Log[2][3].(txvm.Bytes)) {
+		return false
+	}
+	if tx.Log[3][0].(txvm.Bytes)[0] != txvm.LogCode {
+		return false
+	}
+	ref := pegOut{
+		assetBytes,
+		temp,
+		seqnum,
+		exporter,
+	}
+	refdata, err := json.Marshal(ref)
+	if !bytes.Equal(refdata, tx.Log[3][2].(txvm.Bytes)) {
+		return false
+	}
+	// Beyond this, the two transactions diverge but must either finalize
+	// or output the remaining unconsumed input
 	return true
 }
 

--- a/slidechain/slidechain_test.go
+++ b/slidechain/slidechain_test.go
@@ -374,12 +374,12 @@ func TestEndToEnd(t *testing.T) {
 			}
 		}
 		t.Log("submitting pre-export tx...")
-		temp, seqnum, err := SubmitPreExportTx(hclient, exporter, c.AccountID.Address(), native, int64(amount))
+		tempAddr, seqnum, err := SubmitPreExportTx(hclient, exporter, c.AccountID.Address(), native, int64(amount))
 		if err != nil {
 			t.Fatalf("pre-submit tx error: %s", err)
 		}
 		t.Log("building export tx...")
-		exportTx, err := BuildExportTx(ctx, native, int64(amount), int64(amount), temp, anchor, exporterPrv, seqnum)
+		exportTx, err := BuildExportTx(ctx, native, int64(amount), int64(amount), tempAddr, anchor, exporterPrv, seqnum)
 		if err != nil {
 			t.Fatalf("error building retirement tx %s", err)
 		}
@@ -405,7 +405,7 @@ func TestEndToEnd(t *testing.T) {
 			block := item.(*bc.Block)
 			for _, tx := range block.Transactions {
 				// Look for export transaction.
-				if isExportTx(tx, native, int64(amount), temp, exporter.Address(), int64(seqnum)) {
+				if isExportTx(tx, native, int64(amount), tempAddr, exporter.Address(), int64(seqnum)) {
 					t.Logf("found export tx %x", tx.Program)
 					found = true
 					break
@@ -428,7 +428,7 @@ func TestEndToEnd(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				if env.Tx.SourceAccount.Address() != temp {
+				if env.Tx.SourceAccount.Address() != tempAddr {
 					t.Log("source accounts don't match, skipping...")
 					return
 				}


### PR DESCRIPTION
Simplifies checking for the export tx on TxVM in `cmd/export`: rather than repeatedly checking new blocks for the tx, it simply calls the `wait` logic within the `submit` endpoint. Renames `mustDecode` to `mustDecodeHex`, in line with the rest of the codebase. De-exports the `isExportTx` check.