### PR TITLE
slidechain: differentiate uses of temp

### DIFF
--- a/slidechain/cmd/export/export.go
+++ b/slidechain/cmd/export/export.go
@@ -111,13 +111,13 @@ func main() {
 	if err != nil {
 		log.Fatalf("error unmarshaling custodian account id: %s", err)
 	}
-	temp, seqnum, err := slidechain.SubmitPreExportTx(hclient, kp, custodian.Address(), asset, exportAmount)
+	tempAddr, seqnum, err := slidechain.SubmitPreExportTx(hclient, kp, custodian.Address(), asset, exportAmount)
 	if err != nil {
 		log.Fatalf("error submitting pre-export tx: %s", err)
 	}
 
 	// Export funds from slidechain
-	tx, err := slidechain.BuildExportTx(ctx, asset, exportAmount, inputAmount, temp, mustDecode(*anchor), mustDecode(*prv), seqnum)
+	tx, err := slidechain.BuildExportTx(ctx, asset, exportAmount, inputAmount, tempAddr, mustDecode(*anchor), mustDecode(*prv), seqnum)
 	if err != nil {
 		log.Fatalf("error building export tx: %s", err)
 	}
@@ -181,7 +181,7 @@ func main() {
 		}
 		for _, tx := range b.Transactions {
 			// Look for export transaction
-			if slidechain.IsExportTx(tx, asset, inputAmount, temp, kp.Address(), int64(seqnum)) {
+			if slidechain.IsExportTx(tx, asset, inputAmount, tempAddr, kp.Address(), int64(seqnum)) {
 				log.Println("export tx included in txvm chain")
 				return
 			}

--- a/slidechain/export.go
+++ b/slidechain/export.go
@@ -66,22 +66,22 @@ func (c *Custodian) pegOutFromExports(ctx context.Context) {
 		case <-ch:
 		}
 
-		const q = `SELECT txid, amount, asset_xdr, exporter, temp, seqnum FROM exports`
+		const q = `SELECT txid, amount, asset_xdr, exporter, temp_addr, seqnum FROM exports`
 
 		var (
 			txids     [][]byte
 			amounts   []int
 			assetXDRs [][]byte
 			exporters []string
-			temps     []string
+			tempAddrs []string
 			seqnums   []int
 		)
-		err := sqlutil.ForQueryRows(ctx, c.DB, q, func(txid []byte, amount int, assetXDR []byte, exporter string, temp string, seqnum int) {
+		err := sqlutil.ForQueryRows(ctx, c.DB, q, func(txid []byte, amount int, assetXDR []byte, exporter string, tempAddr string, seqnum int) {
 			txids = append(txids, txid)
 			amounts = append(amounts, amount)
 			assetXDRs = append(assetXDRs, assetXDR)
 			exporters = append(exporters, exporter)
-			temps = append(temps, temp)
+			tempAddrs = append(tempAddrs, tempAddr)
 			seqnums = append(seqnums, seqnum)
 		})
 		if err != nil {
@@ -94,9 +94,9 @@ func (c *Custodian) pegOutFromExports(ctx context.Context) {
 				log.Fatalf("unmarshalling asset from XDR %x: %s", assetXDRs[i], err)
 			}
 			var tempID xdr.AccountId
-			err = tempID.SetAddress(temps[i])
+			err = tempID.SetAddress(tempAddrs[i])
 			if err != nil {
-				log.Fatalf("setting temp address to %s: %s", temps[i], err)
+				log.Fatalf("setting temp address to %s: %s", tempAddrs[i], err)
 			}
 			var exporter xdr.AccountId
 			err = exporter.SetAddress(exporters[i])
@@ -134,8 +134,8 @@ func (c *Custodian) pegOutFromExports(ctx context.Context) {
 	}
 }
 
-func (c *Custodian) pegOut(ctx context.Context, exporter xdr.AccountId, asset xdr.Asset, amount int64, temp xdr.AccountId, seqnum xdr.SequenceNumber) error {
-	tx, err := buildPegOutTx(c.AccountID.Address(), exporter.Address(), temp.Address(), c.network, asset, amount, seqnum)
+func (c *Custodian) pegOut(ctx context.Context, exporter xdr.AccountId, asset xdr.Asset, amount int64, tempID xdr.AccountId, seqnum xdr.SequenceNumber) error {
+	tx, err := buildPegOutTx(c.AccountID.Address(), exporter.Address(), tempID.Address(), c.network, asset, amount, seqnum)
 	if err != nil {
 		return errors.Wrap(err, "building peg-out tx")
 	}
@@ -198,7 +198,7 @@ func createTempAccount(hclient horizon.ClientInterface, kp *keypair.Full) (*keyp
 	if err != nil {
 		return nil, 0, errors.Wrap(err, "getting Horizon root")
 	}
-	temp, err := keypair.Random()
+	tempKP, err := keypair.Random()
 	if err != nil {
 		return nil, 0, errors.Wrap(err, "generating random account")
 	}
@@ -209,7 +209,7 @@ func createTempAccount(hclient horizon.ClientInterface, kp *keypair.Full) (*keyp
 		b.BaseFee{Amount: baseFee},
 		b.CreateAccount(
 			b.NativeAmount{Amount: (2 * xlm.Lumen).HorizonString()},
-			b.Destination{AddressOrSeed: temp.Address()},
+			b.Destination{AddressOrSeed: tempKP.Address()},
 		),
 	)
 	if err != nil {
@@ -219,11 +219,11 @@ func createTempAccount(hclient horizon.ClientInterface, kp *keypair.Full) (*keyp
 	if err != nil {
 		return nil, 0, errors.Wrapf(err, "submitting temp account creation tx")
 	}
-	seqnum, err := hclient.SequenceForAccount(temp.Address())
+	seqnum, err := hclient.SequenceForAccount(tempKP.Address())
 	if err != nil {
-		return nil, 0, errors.Wrapf(err, "getting sequence number for temp account %s", temp.Address())
+		return nil, 0, errors.Wrapf(err, "getting sequence number for temp account %s", tempKP.Address())
 	}
-	return temp, seqnum, nil
+	return tempKP, seqnum, nil
 }
 
 // SubmitPreExportTx builds and submits the two pre-export transactions
@@ -232,19 +232,19 @@ func createTempAccount(hclient horizon.ClientInterface, kp *keypair.Full) (*keyp
 // The second transaction sets the signer on the temporary account
 // to be a preauth transaction, which merges the account and pays
 // out the pegged-out funds.
-// The function returns the temporary account ID and sequence number.
+// The function returns the temporary account address and sequence number.
 func SubmitPreExportTx(hclient horizon.ClientInterface, kp *keypair.Full, custodian string, asset xdr.Asset, amount int64) (string, xdr.SequenceNumber, error) {
 	root, err := hclient.Root()
 	if err != nil {
 		return "", 0, errors.Wrap(err, "getting Horizon root")
 	}
 
-	temp, seqnum, err := createTempAccount(hclient, kp)
+	tempKP, seqnum, err := createTempAccount(hclient, kp)
 	if err != nil {
 		return "", 0, errors.Wrap(err, "creating temp account")
 	}
 
-	preauthTx, err := buildPegOutTx(custodian, kp.Address(), temp.Address(), root.NetworkPassphrase, asset, amount, seqnum)
+	preauthTx, err := buildPegOutTx(custodian, kp.Address(), tempKP.Address(), root.NetworkPassphrase, asset, amount, seqnum)
 	if err != nil {
 		return "", 0, errors.Wrap(err, "building preauth tx")
 	}
@@ -263,7 +263,7 @@ func SubmitPreExportTx(hclient horizon.ClientInterface, kp *keypair.Full, custod
 		b.AutoSequence{SequenceProvider: hclient},
 		b.BaseFee{Amount: baseFee},
 		b.SetOptions(
-			b.SourceAccount{AddressOrSeed: temp.Address()},
+			b.SourceAccount{AddressOrSeed: tempKP.Address()},
 			b.MasterWeight(0),
 			b.SetThresholds(1, 1, 1),
 			b.AddSigner(hashStr, 1),
@@ -272,17 +272,17 @@ func SubmitPreExportTx(hclient horizon.ClientInterface, kp *keypair.Full, custod
 	if err != nil {
 		return "", 0, errors.Wrap(err, "building pre-export tx")
 	}
-	_, err = stellar.SignAndSubmitTx(hclient, tx, kp.Seed(), temp.Seed())
+	_, err = stellar.SignAndSubmitTx(hclient, tx, kp.Seed(), tempKP.Seed())
 	if err != nil {
 		return "", 0, errors.Wrap(err, "pre-exporttx")
 	}
-	return temp.Address(), seqnum, nil
+	return tempKP.Address(), seqnum, nil
 }
 
 // BuildExportTx builds a txvm retirement tx for an asset issued
 // onto slidechain. It will retire `amount` of the asset, and the
 // remaining input will be output back to the original account.
-func BuildExportTx(ctx context.Context, asset xdr.Asset, amount, inputAmt int64, temp string, anchor []byte, prv ed25519.PrivateKey, seqnum xdr.SequenceNumber) (*bc.Tx, error) {
+func BuildExportTx(ctx context.Context, asset xdr.Asset, amount, inputAmt int64, tempAddr string, anchor []byte, prv ed25519.PrivateKey, seqnum xdr.SequenceNumber) (*bc.Tx, error) {
 	if inputAmt < amount {
 		return nil, fmt.Errorf("cannot have input amount %d less than export amount %d", inputAmt, amount)
 	}
@@ -300,7 +300,7 @@ func BuildExportTx(ctx context.Context, asset xdr.Asset, amount, inputAmt int64,
 	pubkey := prv.Public().(ed25519.PublicKey)
 	ref := pegOut{
 		assetBytes,
-		temp,
+		tempAddr,
 		int64(seqnum),
 		kp.Address(),
 	}

--- a/slidechain/export_test.go
+++ b/slidechain/export_test.go
@@ -54,12 +54,12 @@ func TestPegOut(t *testing.T) {
 		t.Fatalf("error funding account %s: %s", kp.Address(), err)
 	}
 
-	temp, seqnum, err := SubmitPreExportTx(c.hclient, kp, c.AccountID.Address(), lumen, int64(amount))
+	tempAddr, seqnum, err := SubmitPreExportTx(c.hclient, kp, c.AccountID.Address(), lumen, int64(amount))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = c.DB.Exec("INSERT INTO exports (txid, amount, asset_xdr, temp, seqnum, exporter) VALUES ($1, $2, $3, $4, $5, $6)", "", amount, lumenXDR, temp, seqnum, kp.Address())
+	_, err = c.DB.Exec("INSERT INTO exports (txid, amount, asset_xdr, temp_addr, seqnum, exporter) VALUES ($1, $2, $3, $4, $5, $6)", "", amount, lumenXDR, tempAddr, seqnum, kp.Address())
 	if err != nil && err != context.Canceled {
 		t.Fatal(err)
 	}
@@ -78,7 +78,7 @@ func TestPegOut(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				if env.Tx.SourceAccount.Address() != temp {
+				if env.Tx.SourceAccount.Address() != tempAddr {
 					log.Println("source accounts don't match, skipping...")
 					return
 				}

--- a/slidechain/schema.go
+++ b/slidechain/schema.go
@@ -28,7 +28,7 @@ CREATE TABLE IF NOT EXISTS exports (
   exporter TEXT NOT NULL,
   amount INTEGER NOT NULL,
   asset_xdr BLOB NOT NULL,
-  temp TEXT NOT NULL,
+  temp_addr TEXT NOT NULL,
   seqnum INTEGER NOT NULL
 );
 

--- a/slidechain/slidechain_test.go
+++ b/slidechain/slidechain_test.go
@@ -373,12 +373,12 @@ func TestEndToEnd(t *testing.T) {
 			}
 		}
 		t.Log("submitting pre-export tx...")
-		temp, seqnum, err := SubmitPreExportTx(hclient, exporter, c.AccountID.Address(), native, int64(amount))
+		tempAddr, seqnum, err := SubmitPreExportTx(hclient, exporter, c.AccountID.Address(), native, int64(amount))
 		if err != nil {
 			t.Fatalf("pre-submit tx error: %s", err)
 		}
 		t.Log("building export tx...")
-		exportTx, err := BuildExportTx(ctx, native, int64(amount), int64(amount), temp, anchor, exporterPrv, seqnum)
+		exportTx, err := BuildExportTx(ctx, native, int64(amount), int64(amount), tempAddr, anchor, exporterPrv, seqnum)
 		if err != nil {
 			t.Fatalf("error building retirement tx %s", err)
 		}
@@ -404,7 +404,7 @@ func TestEndToEnd(t *testing.T) {
 			block := item.(*bc.Block)
 			for _, tx := range block.Transactions {
 				// Look for export transaction.
-				if IsExportTx(tx, native, int64(amount), temp, exporter.Address(), int64(seqnum)) {
+				if IsExportTx(tx, native, int64(amount), tempAddr, exporter.Address(), int64(seqnum)) {
 					t.Logf("found export tx %x", tx.Program)
 					found = true
 					break
@@ -427,7 +427,7 @@ func TestEndToEnd(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				if env.Tx.SourceAccount.Address() != temp {
+				if env.Tx.SourceAccount.Address() != tempAddr {
 					t.Log("source accounts don't match, skipping...")
 					return
 				}

--- a/slidechain/watch.go
+++ b/slidechain/watch.go
@@ -155,9 +155,9 @@ func (c *Custodian) watchExports(ctx context.Context) {
 				// then wake up a goroutine that executes peg-outs on the main chain.
 				const q = `
 					INSERT INTO exports 
-					(txid, exporter, amount, asset_xdr, temp, seqnum)
+					(txid, exporter, amount, asset_xdr, temp_addr, seqnum)
 					VALUES ($1, $2, $3, $4, $5, $6)`
-				_, err = c.DB.ExecContext(ctx, q, tx.ID.Bytes(), exporter.Address(), retiredAmount, info.AssetXDR, info.Temp, info.Seqnum)
+				_, err = c.DB.ExecContext(ctx, q, tx.ID.Bytes(), exporter.Address(), retiredAmount, info.AssetXDR, info.TempAddr, info.Seqnum)
 				if err != nil {
 					log.Fatalf("recording export tx: %s", err)
 				}


### PR DESCRIPTION
Differentiates the uses of `temp` across the slidechain export logic. We currently use it interchangeably to refer to differently typed representations of the preauthorization transaction's temporary account ID. Instead, variable names are changed to make their types clearer.