### PR TITLE
zkvm: check the result and return err instead of ignoring it

### DIFF
--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -532,7 +532,7 @@ where
         let mut contract = self.pop_item()?.to_contract()?;
         let p = &contract.predicate;
 
-        self.delegate.verify_point_op(|| p.prove_or(&l, &r));
+        self.delegate.verify_point_op(|| p.prove_or(&l, &r))?;
 
         assign(&mut contract, l, r);
 


### PR DESCRIPTION
Bug was introduced at: https://github.com/interstellar/slingshot/commit/a6e3bcf49b79b4dba2adc0a9241b5766ed105c46#r32435898 (PR #81)