### PR TITLE
spacesuit: deny missing docs

### DIFF
--- a/spacesuit/README.md
+++ b/spacesuit/README.md
@@ -12,9 +12,7 @@ Specs for the Cloak protocol can be [found here][cloak].
 
 ## WARNING
 
-This code is still research-quality.  It is not (yet) suitable for deployment.
-The development roadmap can be found in the [Milestones][milestones] section of the 
-[Github repo][spacesuit_repo].
+This code is still research-quality. It is not (yet) suitable for deployment.
 
 ## Tests 
 
@@ -22,7 +20,7 @@ Run tests with `cargo test`.
 
 ## Benchmarks
 
-This crate uses [criterion.rs][criterion] for benchmarks.  Run
+This crate uses [criterion.rs][criterion] for benchmarks. Run
 benchmarks with `cargo bench`.
 
 ## About
@@ -33,8 +31,7 @@ developed by Henry de Valence, Cathie Yun, and Oleg Andreev.
 [bp_website]: https://crypto.stanford.edu/bulletproofs/
 [bp_repo]: https://github.com/dalek-cryptography/bulletproofs/
 [interstellar]: https://interstellar.com/
-[cloak]: https://github.com/interstellar/spacesuit/blob/master/spec.md
-[milestones]: https://github.com/interstellar/spacesuit/milestones
-[spacesuit_repo]: https://github.com/interstellar/spacesuit
+[cloak]: https://github.com/interstellar/slingshot/blob/main/spacesuit/spec.md
+[spacesuit_repo]: https://github.com/interstellar/slingshot/blob/main/spacesuit
 [spacesuit_crate]: https://crates.io/crates/spacesuit
 [criterion]: https://github.com/japaric/criterion.rs

--- a/spacesuit/src/lib.rs
+++ b/spacesuit/src/lib.rs
@@ -1,3 +1,10 @@
+//! Spacesuit is a pure-Rust implementation of Cloak protocol by Interstellar.
+//! Cloak is a protocol for confidential assets based on the
+//! [Bulletproofs](https://crypto.stanford.edu/bulletproofs/) zero-knowledge proof system.
+//! _Cloaked transactions_ exchange values of different “asset types” (which we call flavors).
+//! See the [Cloak specification](https://github.com/interstellar/slingshot/blob/main/spacesuit/spec.md) for details.
+#![deny(missing_docs)]
+
 extern crate bulletproofs;
 extern crate core;
 extern crate curve25519_dalek;

--- a/spacesuit/src/value.rs
+++ b/spacesuit/src/value.rs
@@ -6,14 +6,21 @@ use rand::{CryptoRng, Rng};
 use std::ops::{Add, Mul};
 use subtle::{Choice, ConditionallySelectable};
 
+/// A pair of a secret _quantity_ (64-bit integer)
+/// and a secret _flavor_ (scalar).
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Value {
-    pub q: SignedInteger, // quantity
-    pub f: Scalar,        // flavor
+    /// Secret quantity
+    pub q: SignedInteger,
+    /// Secret flavor
+    pub f: Scalar,
 }
 
+/// A pair of Pedersen commitments to a secret quantity and flavor.
 pub struct CommittedValue {
+    /// Pedersen commitment to a quantity
     pub q: CompressedRistretto,
+    /// Pedersen commitment to a flavor
     pub f: CompressedRistretto,
 }
 
@@ -21,15 +28,20 @@ pub struct CommittedValue {
 /// 2-tuples of variables and assignments
 #[derive(Copy, Clone, Debug)]
 pub struct AllocatedValue {
-    pub q: Variable, // quantity
-    pub f: Variable, // flavor
+    /// R1CS variable representing the quantity
+    pub q: Variable,
+    /// R1CS variable representing the flavor
+    pub f: Variable,
+    /// Secret assignment to the above variables
     pub assignment: Option<Value>,
 }
 
 /// Represents a variable for quantity, along with its assignment.
 #[derive(Copy, Clone, Debug)]
 pub struct AllocatedQuantity {
+    /// R1CS variable representing the quantity
     pub variable: Variable,
+    /// Secret assignment to the variable
     pub assignment: Option<SignedInteger>,
 }
 
@@ -58,7 +70,7 @@ impl Value {
         })
     }
 
-    pub fn allocate_unassigned<CS: ConstraintSystem>(
+    pub(crate) fn allocate_unassigned<CS: ConstraintSystem>(
         cs: &mut CS,
     ) -> Result<AllocatedValue, R1CSError> {
         let (q_var, f_var, _) = cs.allocate(|| {
@@ -86,7 +98,7 @@ impl AllocatedValue {
     }
 
     // /// Make another `AllocatedValue`, with the same assignment and newly allocated variables.
-    pub fn reallocate<CS: ConstraintSystem>(
+    pub(crate) fn reallocate<CS: ConstraintSystem>(
         &self,
         cs: &mut CS,
     ) -> Result<AllocatedValue, R1CSError> {
@@ -98,8 +110,8 @@ impl AllocatedValue {
 }
 
 impl SignedInteger {
-    // Returns Some(x) if self is non-negative
-    // Otherwise returns None.
+    /// Returns Some(x) if self is non-negative
+    /// Otherwise returns None.
     pub fn to_u64(&self) -> Option<u64> {
         if self.0 < 0 {
             None
@@ -165,9 +177,13 @@ impl Neg for SignedInteger {
     }
 }
 
+/// Extension trait for committing Values to the Prover's constraint system.
+/// TBD: make this private by refactoring the benchmarks.
 pub trait ProverCommittable {
+    /// Type for a result of committing this type to a constraint system.
     type Output;
 
+    /// Commits the type to a constraint system.
     fn commit<R: Rng + CryptoRng>(&self, prover: &mut Prover, rng: &mut R) -> Self::Output;
 }
 
@@ -198,8 +214,13 @@ impl ProverCommittable for Vec<Value> {
     }
 }
 
+/// Extension trait for committing Values to the Verifier's constraint system.
+/// TBD: make this private by refactoring the benchmarks.
 pub trait VerifierCommittable {
+    /// Type for a result of committing this type to a constraint system.
     type Output;
+
+    /// Commits the type to a constraint system.
     fn commit(&self, verifier: &mut Verifier) -> Self::Output;
 }
 

--- a/spacesuit/src/value.rs
+++ b/spacesuit/src/value.rs
@@ -180,7 +180,7 @@ impl Neg for SignedInteger {
 /// Extension trait for committing Values to the Prover's constraint system.
 /// TBD: make this private by refactoring the benchmarks.
 pub trait ProverCommittable {
-    /// Type for a result of committing this type to a constraint system.
+    /// Result of committing Self to a constraint system.
     type Output;
 
     /// Commits the type to a constraint system.
@@ -217,7 +217,7 @@ impl ProverCommittable for Vec<Value> {
 /// Extension trait for committing Values to the Verifier's constraint system.
 /// TBD: make this private by refactoring the benchmarks.
 pub trait VerifierCommittable {
-    /// Type for a result of committing this type to a constraint system.
+    /// Result of committing Self to a constraint system.
     type Output;
 
     /// Commits the type to a constraint system.


### PR DESCRIPTION
This enforces documentation for all exported items in spacesuit.