### PR TITLE
zkvm/types: compute exact serialized length

### DIFF
--- a/zkvm/src/contract.rs
+++ b/zkvm/src/contract.rs
@@ -93,7 +93,7 @@ impl Input {
 
         let contract = FrozenContract { payload, predicate };
 
-        let mut contract_buf = Vec::with_capacity(contract.min_serialized_length());
+        let mut contract_buf = Vec::with_capacity(contract.serialized_length());
         contract.encode(&mut contract_buf);
         let utxo = UTXO::from_output(&contract_buf, &txid);
 
@@ -106,11 +106,11 @@ impl Input {
 }
 
 impl FrozenContract {
-    pub fn min_serialized_length(&self) -> usize {
+    pub fn serialized_length(&self) -> usize {
         let mut size = 32 + 4;
         for item in self.payload.iter() {
             match item {
-                FrozenItem::Data(d) => size += 1 + 4 + d.min_serialized_length(),
+                FrozenItem::Data(d) => size += 1 + 4 + d.serialized_length(),
                 FrozenItem::Value(_) => size += 1 + 64,
             }
         }

--- a/zkvm/src/ops.rs
+++ b/zkvm/src/ops.rs
@@ -111,6 +111,20 @@ impl Opcode {
 }
 
 impl Instruction {
+    /// Returns the number of bytes required to serialize this instruction.
+    pub fn serialized_length(&self) -> usize {
+        match self {
+            Instruction::Push(data) => 1 + 4 + data.serialized_length(),
+            Instruction::Dup(_) => 1 + 4,
+            Instruction::Roll(_) => 1 + 4,
+            Instruction::Range(_) => 1 + 1,
+            Instruction::Cloak(_, _) => 1 + 4 + 4,
+            Instruction::Output(_) => 1 + 4,
+            Instruction::Contract(_) => 1 + 4,
+            _ => 1,
+        }
+    }
+
     /// Returns a parsed instruction from a subslice of the program string, modifying
     /// the subslice according to the bytes the instruction occupies
     /// E.g. a push instruction with 5-byte string occupies 1+4+5=10 bytes,

--- a/zkvm/src/predicate.rs
+++ b/zkvm/src/predicate.rs
@@ -42,6 +42,11 @@ pub enum PredicateWitness {
 }
 
 impl Predicate {
+    /// Returns the number of bytes needed to serialize the Predicate.
+    pub fn serialized_length(&self) -> usize {
+        32
+    }
+
     /// Converts predicate to a compressed point
     pub fn to_point(&self) -> CompressedRistretto {
         match self {

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -358,7 +358,7 @@ impl DataWitness {
         match self {
             DataWitness::Program(instr) => instr.iter().map(|p| p.serialized_length()).sum(),
             DataWitness::Input(b) => 32 + b.contract.serialized_length(),
-            // All other types are encoded as 32-bit points or scalars
+            // All other types are encoded as 32-byte points or scalars
             _ => 32 as usize,
         }
     }

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -358,8 +358,9 @@ impl DataWitness {
         match self {
             DataWitness::Program(instr) => instr.iter().map(|p| p.serialized_length()).sum(),
             DataWitness::Input(b) => 32 + b.contract.serialized_length(),
-            // All other types are encoded as 32-byte points or scalars
-            _ => 32 as usize,
+            DataWitness::Predicate(_) => 32,
+            DataWitness::Commitment(_) => 32,
+            DataWitness::Scalar(_) => 32,
         }
     }
 }

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -273,7 +273,7 @@ impl Data {
     pub fn serialized_length(&self) -> usize {
         match self {
             Data::Opaque(data) => data.len(),
-            Data::Witness(x) => x.serialized_len(),
+            Data::Witness(x) => x.serialized_length(),
         }
     }
 
@@ -354,7 +354,7 @@ impl DataWitness {
         }
     }
 
-    fn serialized_len(&self) -> usize {
+    fn serialized_length(&self) -> usize {
         match self {
             DataWitness::Program(instr) => instr.iter().map(|p| p.serialized_length()).sum(),
             DataWitness::Input(b) => 32 + b.contract.serialized_length(),

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -403,7 +403,7 @@ where
     fn output(&mut self, k: usize) -> Result<(), VMError> {
         let contract = self.pop_contract(k)?;
         let frozen_contract = self.freeze_contract(contract);
-        let mut buf = Vec::with_capacity(frozen_contract.min_serialized_length());
+        let mut buf = Vec::with_capacity(frozen_contract.serialized_length());
         frozen_contract.encode(&mut buf);
         self.txlog.push(Entry::Output(buf));
         Ok(())


### PR DESCRIPTION
Computes exact serialized length for `Data` witness types, rather than providing a lower bound.

Fixes #116 