### PR TITLE
zkvm: streamline Commitment API

### DIFF
--- a/zkvm/src/prover.rs
+++ b/zkvm/src/prover.rs
@@ -30,11 +30,8 @@ impl<'a, 'b> Delegate<r1cs::Prover<'a, 'b>> for Prover<'a, 'b> {
         &mut self,
         com: &Commitment,
     ) -> Result<(CompressedRistretto, r1cs::Variable), VMError> {
-        let (v, v_blinding) = match com {
-            Commitment::Open(w) => (w.value.into(), w.blinding),
-            Commitment::Closed(_) => return Err(VMError::WitnessMissing),
-        };
-        Ok(self.cs.commit(v, v_blinding))
+        let (v, v_blinding) = com.witness().ok_or(VMError::WitnessMissing)?;
+        Ok(self.cs.commit(v.into(), v_blinding))
     }
 
     fn verify_point_op<F>(&mut self, _point_op_fn: F) -> Result<(), VMError>

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -672,11 +672,10 @@ where
     }
 
     fn variable_assignment(&mut self, var: Variable) -> Option<ScalarWitness> {
-        let v_com = &self.variable_commitments[var.index];
-        match &v_com.commitment {
-            Commitment::Closed(_) => None,
-            Commitment::Open(w) => Some(w.value),
-        }
+        self.variable_commitments[var.index]
+            .commitment
+            .witness()
+            .map(|(content, _)| content)
     }
 
     fn unfreeze_contract(&mut self, contract: FrozenContract) -> Contract {


### PR DESCRIPTION
Per #122 this de-emphasizes `CommitmentWitness` and moves all the API to `Commitment`.