### PR TITLE
zkvm: refactor Input/Contract serialization logic

### DIFF
--- a/zkvm/src/constraints.rs
+++ b/zkvm/src/constraints.rs
@@ -7,6 +7,7 @@ use curve25519_dalek::scalar::Scalar;
 use std::iter::FromIterator;
 use std::ops::{Add, Neg};
 
+use crate::encoding;
 use crate::scalar_witness::ScalarWitness;
 
 #[derive(Copy, Clone, Debug)]
@@ -58,7 +59,7 @@ impl Commitment {
     }
 
     pub(crate) fn encode(&self, buf: &mut Vec<u8>) {
-        buf.extend_from_slice(&self.to_point().to_bytes());
+        encoding::write_point(&self.to_point(), buf);
     }
 
     pub fn unblinded<T: Into<ScalarWitness>>(x: T) -> Self {

--- a/zkvm/src/contract.rs
+++ b/zkvm/src/contract.rs
@@ -70,7 +70,7 @@ impl Input {
             .collect();
 
         let prev_output = Output { payload, predicate };
-        let utxo = UTXO::from_output(&prev_output.clone().to_vec(), &txid);
+        let utxo = UTXO::from_output(&prev_output.clone().to_bytes(), &txid);
 
         Input {
             prev_output,
@@ -120,7 +120,7 @@ impl Input {
 
 impl Output {
     /// Converts self to vector of bytes
-    pub(crate) fn to_vec(self) -> Vec<u8> {
+    pub fn to_bytes(self) -> Vec<u8> {
         let mut buf = Vec::with_capacity(self.serialized_length());
         self.encode(&mut buf);
         buf

--- a/zkvm/src/contract.rs
+++ b/zkvm/src/contract.rs
@@ -35,14 +35,14 @@ pub struct Input {
 
 /// Representation of a Contract inside an Input that can be cloned.
 #[derive(Clone, Debug)]
-pub struct FrozenContract {
+pub(crate) struct FrozenContract {
     pub(crate) payload: Vec<FrozenItem>,
     pub(crate) predicate: Predicate,
 }
 
 /// Representation of a PortableItem inside an Input that can be cloned.
 #[derive(Clone, Debug)]
-pub enum FrozenItem {
+pub(crate) enum FrozenItem {
     Data(Data),
     Value(FrozenValue),
 }
@@ -51,7 +51,7 @@ pub enum FrozenItem {
 /// Note: values do not necessarily have open commitments. Some can be reblinded,
 /// others can be passed-through to an output without going through `cloak` and the constraint system.
 #[derive(Clone, Debug)]
-pub struct FrozenValue {
+pub(crate) struct FrozenValue {
     pub(crate) qty: Commitment,
     pub(crate) flv: Commitment,
 }

--- a/zkvm/src/contract.rs
+++ b/zkvm/src/contract.rs
@@ -100,7 +100,7 @@ impl Input {
     }
 
     /// Unfreezes the input by converting it to the Contract an UTXO ID.
-    pub(crate) fn unfreeze<F>(self, mut com_to_var: F) -> (Contract, UTXO)
+    pub(crate) fn unfreeze<F>(self, com_to_var: F) -> (Contract, UTXO)
     where
         F: FnMut(Commitment) -> Variable,
     {
@@ -167,7 +167,7 @@ impl FrozenContract {
 
     /// Converts FrozenContract to a Contract and uses provided closure
     /// to allocate R1CS variables for the Values stored in the contract’s payload.
-    pub(crate) fn unfreeze<F>(self, mut com_to_var: F) -> Contract
+    fn unfreeze<F>(self, mut com_to_var: F) -> Contract
     where
         F: FnMut(Commitment) -> Variable,
     {

--- a/zkvm/src/lib.rs
+++ b/zkvm/src/lib.rs
@@ -34,5 +34,4 @@ pub use self::vm::{Tx, VerifiedTx};
 // TBD: review if we actually need to export these:
 pub use self::constraints::CommitmentWitness;
 pub use self::contract::PortableItem;
-pub use self::contract::{FrozenContract, FrozenItem, FrozenValue};
 pub use self::types::DataWitness;

--- a/zkvm/src/predicate.rs
+++ b/zkvm/src/predicate.rs
@@ -8,6 +8,7 @@ use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
 use merlin::Transcript;
 
+use crate::encoding;
 use crate::errors::VMError;
 use crate::ops::Instruction;
 use crate::point_ops::PointOp;
@@ -57,7 +58,7 @@ impl Predicate {
 
     /// Encodes the Predicate in program bytecode.
     pub fn encode(&self, prog: &mut Vec<u8>) {
-        prog.extend_from_slice(&self.to_point().to_bytes())
+        encoding::write_point(&self.to_point(), prog);
     }
 
     /// Verifies whether the current predicate is a disjunction of two others.

--- a/zkvm/src/scalar_witness.rs
+++ b/zkvm/src/scalar_witness.rs
@@ -3,6 +3,7 @@
 use curve25519_dalek::scalar::Scalar;
 use spacesuit::SignedInteger;
 
+use crate::encoding;
 use crate::errors::VMError;
 use std::ops::{Add, Mul, Neg};
 use std::u64;
@@ -24,7 +25,7 @@ impl ScalarWitness {
 
     /// Converts to a scalar and encodes it to a vec of bytes.
     pub(crate) fn encode(&self, buf: &mut Vec<u8>) {
-        buf.extend_from_slice(&self.to_scalar().to_bytes())
+        encoding::write_bytes(&self.to_scalar().to_bytes(), buf);
     }
 
     /// Converts the witness to an integer if it is an integer

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -192,17 +192,17 @@ impl DataWitness {
             DataWitness::Predicate(p) => p.encode(buf),
             DataWitness::Commitment(c) => c.encode(buf),
             DataWitness::Scalar(s) => s.encode(buf),
-            DataWitness::Input(b) => b.encode(buf),
+            DataWitness::Input(input) => input.encode(buf),
         }
     }
 
     fn serialized_length(&self) -> usize {
         match self {
             DataWitness::Program(instr) => instr.iter().map(|p| p.serialized_length()).sum(),
-            DataWitness::Input(b) => 32 + b.contract.serialized_length(),
             DataWitness::Predicate(p) => p.serialized_length(),
             DataWitness::Commitment(c) => c.serialized_length(),
             DataWitness::Scalar(s) => s.serialized_length(),
+            DataWitness::Input(input) => input.serialized_length(),
         }
     }
 }

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -421,7 +421,7 @@ where
     fn output(&mut self, k: usize) -> Result<(), VMError> {
         let contract = self.pop_contract(k)?;
         let frozen_contract = contract.freeze(|v| self.variable_to_commitment(v));
-        self.txlog.push(Entry::Output(frozen_contract.to_vec()));
+        self.txlog.push(Entry::Output(frozen_contract.to_bytes()));
         Ok(())
     }
 


### PR DESCRIPTION
1. Renames `FrozenContract` to `Output`.
2. Makes other `Frozen*` types private.
3. Moves freezing/unfreezing logic into `contract.rs`.
4. Revisits private/pub(crate) methods.
5. Writing API is streamlined via `encoding::write_*` methods, so we can later remove assumption of `&mut Vec<u8>` and use generic `Writer` trait to make code cleaner and assuming less.

Closes #122.