### PR TITLE
zkvm/vm: add TxHeader type

### DIFF
--- a/zkvm/src/lib.rs
+++ b/zkvm/src/lib.rs
@@ -29,7 +29,7 @@ pub use self::transcript::TranscriptProtocol;
 pub use self::txlog::{Entry, TxID, UTXO};
 pub use self::types::{Data, Item, Value, WideValue};
 pub use self::verifier::Verifier;
-pub use self::vm::{Tx, VerifiedTx};
+pub use self::vm::{Tx, TxHeader, VerifiedTx};
 
 // TBD: review if we actually need to export these:
 pub use self::constraints::CommitmentWitness;

--- a/zkvm/src/prover.rs
+++ b/zkvm/src/prover.rs
@@ -12,7 +12,7 @@ use crate::point_ops::PointOp;
 use crate::predicate::Predicate;
 use crate::signature::Signature;
 use crate::txlog::{TxID, TxLog};
-use crate::vm::{Delegate, Tx, VM};
+use crate::vm::{Delegate, Tx, TxHeader, VM};
 
 pub struct Prover<'a, 'b> {
     signtx_keys: Vec<Scalar>,
@@ -62,9 +62,7 @@ impl<'a, 'b> Delegate<r1cs::Prover<'a, 'b>> for Prover<'a, 'b> {
 impl<'a, 'b> Prover<'a, 'b> {
     pub fn build_tx<'g>(
         program: Vec<Instruction>,
-        version: u64,
-        mintime: u64,
-        maxtime: u64,
+        header: TxHeader,
         bp_gens: &'g BulletproofGens,
     ) -> Result<(Tx, TxID, TxLog), VMError> {
         // Prepare the constraint system
@@ -82,9 +80,7 @@ impl<'a, 'b> Prover<'a, 'b> {
         };
 
         let vm = VM::new(
-            version,
-            mintime,
-            maxtime,
+            header,
             ProverRun {
                 program: program.into(),
             },
@@ -103,9 +99,7 @@ impl<'a, 'b> Prover<'a, 'b> {
 
         Ok((
             Tx {
-                version,
-                mintime,
-                maxtime,
+                header,
                 signature,
                 proof,
                 program: bytecode,

--- a/zkvm/src/txlog.rs
+++ b/zkvm/src/txlog.rs
@@ -2,13 +2,14 @@ use curve25519_dalek::ristretto::CompressedRistretto;
 use merlin::Transcript;
 
 use crate::transcript::TranscriptProtocol;
+use crate::vm::TxHeader;
 
 pub type TxLog = Vec<Entry>;
 
 /// Entry in a transaction log
 #[derive(Clone, PartialEq, Debug)]
 pub enum Entry {
-    Header(u64, u64, u64),
+    Header(TxHeader),
     Issue(CompressedRistretto, CompressedRistretto),
     Retire(CompressedRistretto, CompressedRistretto),
     Input(UTXO),
@@ -77,10 +78,10 @@ impl TxID {
 impl Entry {
     fn commit_to_transcript(&self, t: &mut Transcript) {
         match self {
-            Entry::Header(version, mintime, maxtime) => {
-                t.commit_u64(b"tx.version", *version);
-                t.commit_u64(b"tx.mintime", *mintime);
-                t.commit_u64(b"tx.maxtime", *maxtime);
+            Entry::Header(h) => {
+                t.commit_u64(b"tx.version", h.version);
+                t.commit_u64(b"tx.mintime", h.mintime);
+                t.commit_u64(b"tx.maxtime", h.maxtime);
             }
             Entry::Issue(q, f) => {
                 t.commit_point(b"issue.q", q);

--- a/zkvm/src/verifier.rs
+++ b/zkvm/src/verifier.rs
@@ -79,13 +79,7 @@ impl<'a, 'b> Verifier<'a, 'b> {
             cs: cs,
         };
 
-        let vm = VM::new(
-            tx.version,
-            tx.mintime,
-            tx.maxtime,
-            VerifierRun::new(tx.program),
-            &mut verifier,
-        );
+        let vm = VM::new(tx.header, VerifierRun::new(tx.program), &mut verifier);
 
         let (txid, txlog) = vm.run()?;
 
@@ -107,9 +101,7 @@ impl<'a, 'b> Verifier<'a, 'b> {
             .map_err(|_| VMError::InvalidR1CSProof)?;
 
         Ok(VerifiedTx {
-            version: tx.version,
-            mintime: tx.mintime,
-            maxtime: tx.maxtime,
+            header: tx.header,
             id: txid,
             log: txlog,
         })

--- a/zkvm/tests/zkvm.rs
+++ b/zkvm/tests/zkvm.rs
@@ -89,8 +89,12 @@ fn test_helper(program: Vec<Instruction>) -> Result<TxID, VMError> {
     let (tx, txid, txlog) = {
         // Build tx
         let bp_gens = BulletproofGens::new(256, 1);
-        // TBD: add TxHeader type to make this call more readable
-        Prover::build_tx(program, 0u64, 0u64, 0u64, &bp_gens)?
+        let header = TxHeader {
+            version: 0u64,
+            mintime: 0u64,
+            maxtime: 0u64,
+        };
+        Prover::build_tx(program, header, &bp_gens)?
     };
 
     // Verify tx


### PR DESCRIPTION
Adds `TxHeader` type, used in `Tx`, `VerifiedTx`, `TxLog::Entry`, and `build_tx` 

Fixes #132 