### PR TITLE
slidechain: streamline parsing in export and peg cmds

### DIFF
--- a/slidechain/cmd/export/export.go
+++ b/slidechain/cmd/export/export.go
@@ -62,16 +62,14 @@ func main() {
 
 	// XDR scales down an amount unit of every asset by a factor of 10^7.
 	// Thus, xlm.Parse works for both native and non-native assets.
-	exportXlm, err := xlm.Parse(*amount)
+	exportAmount, err := xlm.Parse(*amount)
 	if err != nil {
 		log.Fatalf("error parsing export amount %s: %s", *amount, err)
 	}
-	exportAmount := int64(exportXlm)
-	inputXlm, err := xlm.Parse(*input)
+	inputAmount, err := xlm.Parse(*input)
 	if err != nil {
 		log.Fatalf("error parsing input amount %s: %s", *input, err)
 	}
-	inputAmount := int64(inputXlm)
 
 	*slidechaind = strings.TrimRight(*slidechaind, "/")
 
@@ -99,13 +97,13 @@ func main() {
 	if err != nil {
 		log.Fatalf("error unmarshaling custodian account id: %s", err)
 	}
-	tempAddr, seqnum, err := slidechain.SubmitPreExportTx(hclient, kp, custodian.Address(), asset, exportAmount)
+	tempAddr, seqnum, err := slidechain.SubmitPreExportTx(hclient, kp, custodian.Address(), asset, int64(exportAmount))
 	if err != nil {
 		log.Fatalf("error submitting pre-export tx: %s", err)
 	}
 
 	// Export funds from slidechain.
-	tx, err := slidechain.BuildExportTx(ctx, asset, exportAmount, inputAmount, tempAddr, mustDecodeHex(*anchor), rawbytes, seqnum)
+	tx, err := slidechain.BuildExportTx(ctx, asset, int64(exportAmount), int64(inputAmount), tempAddr, mustDecodeHex(*anchor), rawbytes, seqnum)
 	if err != nil {
 		log.Fatalf("error building export tx: %s", err)
 	}

--- a/slidechain/cmd/export/export.go
+++ b/slidechain/cmd/export/export.go
@@ -50,17 +50,14 @@ func main() {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
-	var (
-		asset xdr.Asset
-		err   error
-	)
+
+	var err error
+	asset := stellar.NativeAsset()
 	if *code != "" {
 		asset, err = stellar.NewAsset(*code, *issuer)
 		if err != nil {
 			log.Fatalf("error creating asset from code %s and issuer %s: %s", *code, *issuer, err)
 		}
-	} else {
-		asset = stellar.NativeAsset()
 	}
 
 	// XDR scales down an amount unit of every asset by a factor of 10^7.

--- a/slidechain/cmd/peg/peg.go
+++ b/slidechain/cmd/peg/peg.go
@@ -16,7 +16,6 @@ import (
 	"github.com/chain/txvm/protocol/bc"
 	"github.com/golang/protobuf/proto"
 	"github.com/stellar/go/clients/horizon"
-	"github.com/stellar/go/xdr"
 
 	"github.com/interstellar/slingshot/slidechain"
 	"github.com/interstellar/slingshot/slidechain/stellar"
@@ -77,21 +76,11 @@ func main() {
 	if err != nil {
 		log.Fatal("decoding initial block id: ", err)
 	}
-	var asset xdr.Asset
-	if *issuer != "" {
-		var issuerID xdr.AccountId
-		err = issuerID.SetAddress(*issuer)
+	asset := stellar.NativeAsset()
+	if *code != "" {
+		asset, err = stellar.NewAsset(*code, *issuer)
 		if err != nil {
-			log.Fatal("setting issuer ID: ", err)
-		}
-		err = asset.SetCredit(*code, issuerID)
-		if err != nil {
-			log.Fatal("setting asset code and issuer: ", err)
-		}
-	} else {
-		asset, err = xdr.NewAsset(xdr.AssetTypeAssetTypeNative, nil)
-		if err != nil {
-			log.Fatal("setting native asset: ", err)
+			log.Fatalf("error creating asset from code %s and issuer %s: %s", *code, *issuer, err)
 		}
 	}
 


### PR DESCRIPTION
Streamlines amount and asset parsing in `cmd/export` and `cmd/peg`.