### PR TITLE
zkvm: implement `and`, `or`, `verify` instructions

### DIFF
--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -1368,6 +1368,7 @@ _constr_ **verify** → ø
 2. Transforms the constraint `constr` recursively using the following rules:
     1. Replace conjunction of two _linear constraints_ `a` and `b` with a linear constraint `c` by combining both constraints with a random challenge `z`:
         ```
+        z = transcript.challenge_scalar(b"ZkVM.verify.and-challenge");
         c = a + z·b
         ```
     2. Replace disjunction of two _linear constraints_ `a` and `b` by constrainting an output `o` of a newly allocated multiplier `{r,l,o}` to zero, while adding constraints `r == a` and `l == b` to the constraint system.

--- a/zkvm/src/constraints.rs
+++ b/zkvm/src/constraints.rs
@@ -58,8 +58,6 @@ impl Constraint {
             cs.constrain(expr.to_r1cs_lc());
 
             Ok(())
-            // question: shouldn't this converseion from R1CSError -> VMError happen automatically
-            // because I implemented the `From<R1CSError> for VMError` trait?
         })
         .map_err(|e| VMError::R1CSError(e))
     }

--- a/zkvm/src/constraints.rs
+++ b/zkvm/src/constraints.rs
@@ -257,14 +257,6 @@ impl Add for Expression {
     }
 }
 
-impl Sub for Expression {
-    type Output = Expression;
-
-    fn sub(self, rhs: Expression) -> Expression {
-        self + -rhs
-    }
-}
-
 // Upcasting witness/points into Commitment
 
 impl From<CommitmentWitness> for Commitment {

--- a/zkvm/src/errors.rs
+++ b/zkvm/src/errors.rs
@@ -1,4 +1,5 @@
 //! Errors related to proving and verifying proofs.
+use bulletproofs::r1cs::R1CSError;
 
 /// Represents an error in proof creation, verification, or parsing.
 #[derive(Fail, Clone, Debug, Eq, PartialEq)]
@@ -107,9 +108,19 @@ pub enum VMError {
     #[fail(display = "R1CS detected inconsistent input")]
     R1CSInconsistency,
 
+    /// This error occurs when an R1CSError is returned from the ConstraintSystem.
+    #[fail(display = "R1CSError returned when trying to build R1CS instance")]
+    R1CSError(R1CSError),
+
     #[fail(display = "Item misses witness data.")]
     WitnessMissing,
 
     #[fail(display = "Data item must be opaque")]
     DataNotOpaque,
+}
+
+impl From<R1CSError> for VMError {
+    fn from(e: R1CSError) -> VMError {
+        VMError::R1CSError(e)
+    }
 }

--- a/zkvm/src/errors.rs
+++ b/zkvm/src/errors.rs
@@ -118,9 +118,3 @@ pub enum VMError {
     #[fail(display = "Data item must be opaque")]
     DataNotOpaque,
 }
-
-impl From<R1CSError> for VMError {
-    fn from(e: R1CSError) -> VMError {
-        VMError::R1CSError(e)
-    }
-}

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -57,28 +57,11 @@ impl Item {
         }
     }
 
-    // Downcasts to a portable type
-    pub fn to_portable(self) -> Result<PortableItem, VMError> {
+    // Downcasts to Contract type
+    pub fn to_contract(self) -> Result<Contract, VMError> {
         match self {
-            Item::Data(x) => Ok(PortableItem::Data(x)),
-            Item::Value(x) => Ok(PortableItem::Value(x)),
-            _ => Err(VMError::TypeNotPortable),
-        }
-    }
-
-    // Downcasts to Variable type
-    pub fn to_variable(self) -> Result<Variable, VMError> {
-        match self {
-            Item::Variable(v) => Ok(v),
-            _ => Err(VMError::TypeNotVariable),
-        }
-    }
-
-    // Downcasts to Expression type (Variable is NOT casted to Expression)
-    pub fn to_expression(self) -> Result<Expression, VMError> {
-        match self {
-            Item::Expression(expr) => Ok(expr),
-            _ => Err(VMError::TypeNotExpression),
+            Item::Contract(c) => Ok(c),
+            _ => Err(VMError::TypeNotContract),
         }
     }
 
@@ -98,11 +81,36 @@ impl Item {
         }
     }
 
-    // Downcasts to Contract type
-    pub fn to_contract(self) -> Result<Contract, VMError> {
+    // Downcasts to Variable type
+    pub fn to_variable(self) -> Result<Variable, VMError> {
         match self {
-            Item::Contract(c) => Ok(c),
-            _ => Err(VMError::TypeNotContract),
+            Item::Variable(v) => Ok(v),
+            _ => Err(VMError::TypeNotVariable),
+        }
+    }
+
+    // Downcasts to Expression type (Variable is NOT casted to Expression)
+    pub fn to_expression(self) -> Result<Expression, VMError> {
+        match self {
+            Item::Expression(expr) => Ok(expr),
+            _ => Err(VMError::TypeNotExpression),
+        }
+    }
+
+    // Downcasts to Constraint type
+    pub fn to_constraint(self) -> Result<Constraint, VMError> {
+        match self {
+            Item::Constraint(c) => Ok(c),
+            _ => Err(VMError::TypeNotConstraint),
+        }
+    }
+
+    // Downcasts to a portable type
+    pub fn to_portable(self) -> Result<PortableItem, VMError> {
+        match self {
+            Item::Data(x) => Ok(PortableItem::Data(x)),
+            Item::Value(x) => Ok(PortableItem::Value(x)),
+            _ => Err(VMError::TypeNotPortable),
         }
     }
 }

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -207,8 +207,8 @@ where
                 Instruction::Mul => self.mul()?,
                 Instruction::Eq => self.eq()?,
                 Instruction::Range(_) => unimplemented!(),
-                Instruction::And => unimplemented!(),
-                Instruction::Or => unimplemented!(),
+                Instruction::And => self.and()?,
+                Instruction::Or => self.or()?,
                 Instruction::Verify => unimplemented!(),
                 Instruction::Blind => unimplemented!(),
                 Instruction::Reblind => unimplemented!(),
@@ -314,6 +314,22 @@ where
         let expr1 = self.pop_item()?.to_expression()?;
         let constraint = Constraint::Eq(expr1, expr2);
         self.push_item(constraint);
+        Ok(())
+    }
+
+    fn and(&mut self) -> Result<(), VMError> {
+        let c2 = self.pop_item()?.to_constraint()?;
+        let c1 = self.pop_item()?.to_constraint()?;
+        let c3 = Constraint::And(vec![c1, c2]);
+        self.push_item(c3);
+        Ok(())
+    }
+
+    fn or(&mut self) -> Result<(), VMError> {
+        let c2 = self.pop_item()?.to_constraint()?;
+        let c1 = self.pop_item()?.to_constraint()?;
+        let c3 = Constraint::Or(vec![c1, c2]);
+        self.push_item(c3);
         Ok(())
     }
 

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -209,7 +209,7 @@ where
                 Instruction::Range(_) => unimplemented!(),
                 Instruction::And => self.and()?,
                 Instruction::Or => self.or()?,
-                Instruction::Verify => unimplemented!(),
+                Instruction::Verify => self.verify()?,
                 Instruction::Blind => unimplemented!(),
                 Instruction::Reblind => unimplemented!(),
                 Instruction::Unblind => unimplemented!(),
@@ -320,7 +320,7 @@ where
     fn and(&mut self) -> Result<(), VMError> {
         let c2 = self.pop_item()?.to_constraint()?;
         let c1 = self.pop_item()?.to_constraint()?;
-        let c3 = Constraint::And(vec![c1, c2]);
+        let c3 = Constraint::And(Box::new(c1), Box::new(c2));
         self.push_item(c3);
         Ok(())
     }
@@ -328,8 +328,14 @@ where
     fn or(&mut self) -> Result<(), VMError> {
         let c2 = self.pop_item()?.to_constraint()?;
         let c1 = self.pop_item()?.to_constraint()?;
-        let c3 = Constraint::Or(vec![c1, c2]);
+        let c3 = Constraint::Or(Box::new(c1), Box::new(c2));
         self.push_item(c3);
+        Ok(())
+    }
+
+    fn verify(&mut self) -> Result<(), VMError> {
+        let constraint = self.pop_item()?.to_constraint()?;
+        constraint.verify(self.delegate.cs());
         Ok(())
     }
 

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -335,7 +335,7 @@ where
 
     fn verify(&mut self) -> Result<(), VMError> {
         let constraint = self.pop_item()?.to_constraint()?;
-        constraint.verify(self.delegate.cs());
+        constraint.verify(self.delegate.cs())?;
         Ok(())
     }
 


### PR DESCRIPTION
- change `Constraint::{And, Or}` to be a tuple of two boxed constraints, instead of a vector (since they'll only ever be created from two constraints anyways, and we can do the flattening in the `verify` function
- implement `and`, `or` using the new Constraint type
- implement `verify`: enter 2nd phase of 2-phase challenge API, in order to get `z` challenge. Then recursively "flatten" the constraint, until the base case `Expression` type, and combine the `Expression`s according to the rules until you have one `Expression` that represents the whole constraint. Then push that constraint onto the constraint system.

Question: I implemented the `From<R1CSError> for VMError` trait, but in `verify` it does not automatically convert `R1CSError` to `VMError`, so I have to do it explicitly. I thought this would be implicit because of the `From` trait?
Update: What I'd want is `TryFrom`, which is nightly-only. So I'll just do explicit conversion for now!