### PR TITLE
slingshot: check all the markdown references

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ branches:
 matrix:
   fast_finish: true
   include:
+  - language: ruby
+    ruby: 2.3
+    script:
+      - ruby check-markdown-links.rb
   - language: go
     go: 1.11
     install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
   - language: ruby
     ruby: 2.3
     script:
-      - CHECK_HTTP_LINKS=1 ruby check-markdown-links.rb
+      - ruby check-markdown-links.rb
   - language: go
     go: 1.11
     install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
   - language: ruby
     ruby: 2.3
     script:
-      - ruby check-markdown-links.rb
+      - CHECK_HTTP_LINKS=1 ruby check-markdown-links.rb
   - language: go
     go: 1.11
     install: true

--- a/check-markdown-links.rb
+++ b/check-markdown-links.rb
@@ -23,7 +23,7 @@ def main
     collect_links_and_anchors(file, dataset)
   end
   markdown_filepaths.each do |file|
-    #$stderr.puts "Checking links in #{file}..."
+    puts "Checking links in #{file}"
     check_links(file, dataset[file][:links], dataset)
   end
 end
@@ -141,4 +141,6 @@ main
 
 if $check_links_failed
   exit(1)
+else
+  puts "All links seem to be good."
 end

--- a/check-markdown-links.rb
+++ b/check-markdown-links.rb
@@ -16,6 +16,8 @@ def main
   dataset = {}
   markdown_filepaths = Dir["**/*.md"]
 
+  markdown_filepaths.delete_if{|f| f =~ %r{/vendor/} }
+
   markdown_filepaths.each do |file|
     #$stderr.puts "Collecting links and anchors from #{file}..."
     collect_links_and_anchors(file, dataset)

--- a/check-markdown-links.rb
+++ b/check-markdown-links.rb
@@ -1,0 +1,142 @@
+#!/usr/bin/env ruby
+require 'open-uri'
+require 'pathname'
+require 'pp'
+CHECK_HTTP_LINKS = !!ENV["CHECK_HTTP_LINKS"]
+
+# 1. Get all links
+# 2. For each link, check if it's good:
+#   a. If it's local anchor, check if it's in the list of anchors.
+#   b. If it's local file, fetch that file and check if it's in that file's anchors.
+#   c. If it's global URL, fetch URL to see if it's not 404 and well-formed.
+
+$check_links_failed = false
+
+def main
+  dataset = {}
+  markdown_filepaths = Dir["**/*.md"]
+
+  markdown_filepaths.each do |file|
+    #$stderr.puts "Collecting links and anchors from #{file}..."
+    collect_links_and_anchors(file, dataset)
+  end
+  markdown_filepaths.each do |file|
+    #$stderr.puts "Checking links in #{file}..."
+    check_links(file, dataset[file][:links], dataset)
+  end
+end
+
+def canonicalize_path_in_file(relpath, srcfilepath)
+  abspath = File.expand_path(relpath, File.dirname(srcfilepath))
+  # make relative to the current directory
+  Pathname.new(abspath).relative_path_from(Pathname.new(Dir.pwd)).to_s
+end
+
+def collect_links_and_anchors(fp, dataset={})
+  f = File.read(fp) || ""
+  dataset[fp] ||= {links:nil, anchors:nil}
+  ds = dataset[fp]
+  ds[:links] ||= begin
+    links = []
+    f.dup.split("\n").each_with_index do |line, line_index|
+      line.scan(%r{\[([^\]]*)\]\(([^\)]*)\)}m).each do |(title, ref)|
+        lineno = line_index + 1
+        links << [title, ref, lineno]
+      end
+    end
+    links
+  end
+  ds[:anchors] ||= begin
+    extract_anchors(f)
+  end
+end
+
+def check_links(file, links, dataset = {})
+  dataset["__checked_remote_urls"] ||= {}
+  cache = dataset["__checked_remote_urls"]
+  links.each do |(name, ref, lineno)|
+    if ref[0,1] == "#"
+      if !dataset[file][:anchors].include?(ref)
+        $stderr.puts   "#{file}:#{lineno}: invalid anchor: [#{name}](#{ref})"
+        $check_links_failed = true
+      end
+    elsif ref =~ %r{^https?://}
+      if !cache[ref]
+        if !check_url(ref)
+          $stderr.puts "#{file}:#{lineno}: external file does not load: [#{name}](#{ref})"
+          $check_links_failed = true
+          cache[ref] = "failed"
+        else
+          cache[ref] = "ok"
+        end
+      end
+    else # cross-file link
+      ref = ref.sub(%r{^\./},"")
+      fn, anchor = ref.split("#")
+      anchor = "##{anchor}" if anchor
+
+      linked_fn = canonicalize_path_in_file(fn, file)
+
+      if f = dataset[linked_fn]
+        if !anchor
+          # do nothing - we don't link to anything
+        elsif !f[:anchors].include?(anchor)
+          $stderr.puts "#{file}:#{lineno}: invalid anchor: [#{name}](#{ref}) (check headings in #{linked_fn})"
+          $check_links_failed = true
+        end
+      else
+        if !anchor && check_url(linked_fn)
+          # the reference is fine: the non-markdown file exists somewhere and we link to it as a whole
+        else
+          $stderr.puts "#{file}:#{lineno}: referenced file does not exists: [#{name}](#{ref}) (expanded to #{linked_fn})"
+          $check_links_failed = true
+        end
+      end
+    end
+  end
+end
+
+def check_url(url)
+  if url == "https://dx.doi.org/10.6028/NIST.FIPS.202"
+    return true
+  elsif !CHECK_HTTP_LINKS && url =~ /^https?:/
+    return true
+  else
+    # check that file exists
+    x = open(url).read rescue nil
+    !!x
+  end
+end
+
+def extract_anchors(data)
+  results = [] # list of anchors
+  data.split("\n").each do |line|
+    if h = extract_heading(line)
+      depth, title, anchor = h
+      results << anchor
+    end
+  end
+  results
+end
+
+# Returns `nil` or `[depth, title, anchor]`
+def extract_heading(line)
+  if line =~ /^(#+)\s(.*)/
+    prefix = $1
+    title = $2
+    depth = prefix.size
+    anchor = "#" + title.
+          downcase.
+          gsub(/\W+/,"-").gsub(/(\d)\-(\d)/,"\\1\\2").
+          gsub(/^\-+/,"").
+          gsub(/\-+$/,"")
+
+    [depth, title, anchor]
+  end  
+end
+
+main
+
+if $check_links_failed
+  exit(1)
+end

--- a/keytree/keytree.md
+++ b/keytree/keytree.md
@@ -20,7 +20,7 @@ Every scalar is required to be in a canonical (reduced) form.
 
 A _point_ is an element in the [Ristretto group](https://ristretto.group).
 
-Points are encoded as 32-byte [data types](#data-type) in _compressed Ristretto form_.
+Points are encoded as _compressed Ristretto points_ (32-byte strings).
 
 
 ### Base point

--- a/slidechain/Running.md
+++ b/slidechain/Running.md
@@ -70,6 +70,6 @@ $ ./export -prv [exporter prv key] -amount 50 -inputamt 100 -anchor [import anch
 `slidechaind` will print logs that it is retiring the funds and building a peg-out transaction.
 Using the logged transaction hash,
 we can check that the transaction hit the network and the funds have been pegged out on
-[Stellar Expert](stellar.expert/explorer/testnet/network-activity)
+[Stellar Expert](https://stellar.expert/explorer/testnet/network-activity)
 or using the
 [Stellar Laboratory](https://www.stellar.org/laboratory/#explorer?network=test).

--- a/spacesuit/spec.md
+++ b/spacesuit/spec.md
@@ -10,8 +10,6 @@ _Cloak_ is a protocol for confidential assets based on the [Bulletproofs](https:
     * [Value](#value)
     * [Quantity](#quantity)
     * [Flavor](#flavor)
-    * [Issuer](#issuer)
-    * [Tag](#tag)
     * [Gadget](#gadget)
     * [Transaction](#transaction)
     * [K-scalar shuffle](#k-scalar-shuffle)
@@ -181,7 +179,7 @@ For K = 1:
 
 ### K-value shuffle
 
-Represents a permutation of tuples ([quantity](#quantity), [issuer](#issuer), [tag](#tag)).
+Represents a permutation of tuples ([quantity](#quantity), [flavor](#flavor)).
 
 Each tuple of [scalars](#scalar) `(q, f)` is combined into a single scalar using a free variable `w`:
 
@@ -204,16 +202,16 @@ It is implemented as allocation of two variables and two constraints enforcing z
 In case `M == N`, no padding is required as all shuffles have the same number of inputs and outputs.
 
 In case `M > N` (more inputs than outputs), the padding is applied to the _outputs_ to the middle [shuffle](#k-value-shuffle):
-prover sorts unnecessary zero [values](#values) coming from [M-merge](#k-merge) to the end of the outputs list,
+prover sorts unnecessary zero [values](#value) coming from [M-merge](#k-merge) to the end of the outputs list,
 and verifier constraints them to all-zero tuples.
 
 In case `N < M` (less inputs than outputs), the padding is applied to the _inputs_ to the middle [shuffle](#k-value-shuffle):
-prover adds required zero [values](#values) in the clear to the end of the inputs list,
+prover adds required zero [values](#value) in the clear to the end of the inputs list,
 and secretly sorts them in required position for the subsequent [splits](#k-split).
 
 ### Mix
 
-A _mix_ gadget proves that two [values](#values) either remain _unchanged_,
+A _mix_ gadget proves that two [values](#value) either remain _unchanged_,
 or are _redistributed_ with one value being zero.
     
     Mix(A,B,C,D):

--- a/spacesuit/src/cloak.rs
+++ b/spacesuit/src/cloak.rs
@@ -4,8 +4,7 @@ use shuffle::{padded_shuffle, value_shuffle};
 use value::AllocatedValue;
 
 /// Enforces that the outputs are a valid rearrangement of the inputs, following the
-/// soundness and secrecy requirements in the spacesuit transaction spec:
-/// https://github.com/interstellar/spacesuit/blob/master/spec.md
+/// soundness and secrecy requirements in the [Cloak specification](../spec.md).
 pub fn cloak<CS: ConstraintSystem>(
     cs: &mut CS,
     inputs: Vec<AllocatedValue>,

--- a/zkvm/README.md
+++ b/zkvm/README.md
@@ -43,4 +43,4 @@ All instructions that perform relatively expensive scalar-point multiplications 
 * [Merlin transcripts](https://doc.dalek.rs/merlin/index.html)
 * [Ristretto group](https://ristretto.group)
 * [Bulletproofs R1CS](https://doc-internal.dalek.rs/develop/bulletproofs/notes/r1cs_proof/index.html)
-* [Cloak](https://github.com/interstellar/spacesuit/blob/master/spec.md)
+* [Cloak](../spacesuit/spec.md)

--- a/zkvm/docs/zkvm-api.md
+++ b/zkvm/docs/zkvm-api.md
@@ -5,7 +5,7 @@ but does not describe how to _create_ such transactions. This is the goal of thi
 
 ## Prover and Verifier APIs
 
-The [`Prover`](src/prover.rs) and [`Verifier`](src/verifier.rs) are two entry points to the ZkVM:
+The [`Prover`](../src/prover.rs) and [`Verifier`](../src/verifier.rs) are two entry points to the ZkVM:
 
 `Prover` is an API for _creating_ a transaction object `Tx` out of a stream of `Instruction`s:
 `VM` executes the instructions, producing a serialized program bytecode, aggregated transaction signature
@@ -61,7 +61,7 @@ A [`signtx`](zkvm-spec.md#signtx) instruction expects a [predicate point](zkvm-s
 
 ### Contracts
 
-An [`input`](#input) instruction decodes a serialized contract. In the prover’s VM it pops an `Input` item from the stack that contains a previously created `Output` object with usual data items (with witnesses) and “frozen values”: values where quantity and flavors are represented by [open commitments](#commitments) instead of variables.
+An [`input`](zkvm-spec.md#input) instruction decodes a serialized contract. In the prover’s VM it pops an `Input` item from the stack that contains a previously created `Output` object with usual data items (with witnesses) and “frozen values”: values where quantity and flavors are represented by [open commitments](#commitments) instead of variables.
 
 The VM extracts the `Output` object from the `Input` and converts it to a [Contract type](zkvm-spec.md#contract-type) by allocating variables for each commitment within frozen values, turning them into actual [Value](zkvm-spec.md#value-type) types.
 

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -1330,7 +1330,7 @@ Fails if `ex1` and `ex2` are not both [expression types](#expression-type).
 _expr_ **range:_n_** → _expr_
 
 1. Pops an [expression](#expression-type) `expr`.
-2. Adds an `n`-bit range proof for `expr` to the [constraint system](#constraint-system) (see [Cloak protocol](https://github.com/interstellar/spacesuit/blob/master/spec.md) for the range proof definition).
+2. Adds an `n`-bit range proof for `expr` to the [constraint system](#constraint-system) (see [Cloak protocol](../../spacesuit/spec.md) for the range proof definition).
 3. Pushes `expr` back to the stack.
 
 Immediate data `n` is encoded as one byte.
@@ -1461,7 +1461,7 @@ _qty flv pred_ **issue** → _contract_
     ```
     flv == flavor·B
     ```
-7. Adds a 64-bit range proof for the `qty` to the [constraint system](#constraint-system) (see [Cloak protocol](https://github.com/interstellar/spacesuit/blob/master/spec.md) for the range proof definition).
+7. Adds a 64-bit range proof for the `qty` to the [constraint system](#constraint-system) (see [Cloak protocol](../../spacesuit/spec.md) for the range proof definition).
 8. Adds an [issue entry](#issue-entry) to the [transaction log](#transaction-log).
 9. Creates a [contract](#contract-type) with the value as the only [payload](#contract-payload), protected by the predicate `pred`.
 
@@ -1480,7 +1480,7 @@ _qty flv_ **borrow** → _–V +V_
 1. Pops [variable](#variable-type) `flv`; if the variable is detached, attaches it.
 2. Pops [variable](#variable-type) `qty`; if the variable is detached, attaches it.
 3. Creates a [value](#value-type) `+V` with variables `qty` and `flv` for quantity and flavor, respectively.
-4. Adds a 64-bit range proof for `qty` variable to the [constraint system](#constraint-system) (see [Cloak protocol](https://github.com/interstellar/spacesuit/blob/master/spec.md) for the range proof definition).
+4. Adds a 64-bit range proof for `qty` variable to the [constraint system](#constraint-system) (see [Cloak protocol](../../spacesuit/spec.md) for the range proof definition).
 5. Creates [wide value](#wide-value-type) `–V`, allocating a low-level variable `qty2` for the negated quantity and reusing the flavor variable `flv`.
 6. Adds a constraint `qty2 == -qty` to the constraint system.
 7. Pushes `–V`, then `+V` to the stack.
@@ -1524,7 +1524,7 @@ Merges and splits `m` [wide values](#wide-value-type) into `n` [values](#value-t
 
 1. Pops `2·n` [points](#point) as pairs of _flavor_ and _quantity_ for each output value, flavor is popped first in each pair.
 2. Pops `m` [wide values](#wide-value-type) as input values.
-3. Creates constraints and 64-bit range proofs for quantities per [Cloak protocol](https://github.com/interstellar/spacesuit/blob/master/spec.md).
+3. Creates constraints and 64-bit range proofs for quantities per [Cloak protocol](../../spacesuit/spec.md).
 4. Pushes `n` [values](#value-type) to the stack, placing them in the same order as their corresponding commitments.
 
 Immediate data `m` and `n` are encoded as two [LE32](#le32)s.


### PR DESCRIPTION
This adds a script that checks that most references in the specs are valid:

1. Checks all the local anchors within each `.md` file.
2. Checks all cross-file references and anchors between `.md` files.
3. Checks if remote URLs are loadable (pings `http(s)://` links).
4. Travis checks these on each PR.
5. `/vendor/` paths are ignored.

### Limitations

1. The title-to-anchor convertor is ad-hoc and may not produce the same result as Github/Markdown, so this may turn into false negatives or false positives.
2. Links to anchors to remote pages are not fully checked: only the URL is pinged, but the anchor within it is not verified (so it may become stale).
3. Remote URLs may die causing your PRs be rejected by Travis. In such case it's a good opportunity to fix the URLs or revisit the strictness of the script.

