### PR TITLE
zkvm/vm: embed metadata in flavor

### DIFF
--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -1138,7 +1138,7 @@ Code | Instruction                | Stack diagram                              |
 0x14 | [`unblind`](#unblind)      |        _v V expr_ → _var_                  | Modifies [CS](#constraint-system), [Defers point ops](#deferred-point-operations)
  |                                |                                            |
  |     [**Values**](#value-instructions)              |                        |
-0x15 | [`issue`](#issue)          |    _qty flv data pred_ → _contract_             | Modifies [CS](#constraint-system), [tx log](#transaction-log), [defers point ops](#deferred-point-operations)
+0x15 | [`issue`](#issue)          |    _qty flv data pred_ → _contract_        | Modifies [CS](#constraint-system), [tx log](#transaction-log), [defers point ops](#deferred-point-operations)
 0x16 | [`borrow`](#borrow)        |         _qty flv_ → _–V +V_                | Modifies [CS](#constraint-system)
 0x17 | [`retire`](#retire)        |           _value_ → ø                      | Modifies [CS](#constraint-system), [tx log](#transaction-log)
 0x18 | [`qty`](#qty)              |           _value_ → _value qtyvar_         |

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -1138,7 +1138,7 @@ Code | Instruction                | Stack diagram                              |
 0x14 | [`unblind`](#unblind)      |        _v V expr_ → _var_                  | Modifies [CS](#constraint-system), [Defers point ops](#deferred-point-operations)
  |                                |                                            |
  |     [**Values**](#value-instructions)              |                        |
-0x15 | [`issue`](#issue)          |    _qty flv pred_ → _contract_             | Modifies [CS](#constraint-system), [tx log](#transaction-log), [defers point ops](#deferred-point-operations)
+0x15 | [`issue`](#issue)          |    _qty flv data pred_ → _contract_             | Modifies [CS](#constraint-system), [tx log](#transaction-log), [defers point ops](#deferred-point-operations)
 0x16 | [`borrow`](#borrow)        |         _qty flv_ → _–V +V_                | Modifies [CS](#constraint-system)
 0x17 | [`retire`](#retire)        |           _value_ → ø                      | Modifies [CS](#constraint-system), [tx log](#transaction-log)
 0x18 | [`qty`](#qty)              |           _value_ → _value qtyvar_         |

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -1445,7 +1445,7 @@ Fails if:
 
 #### issue
 
-_qty metadata flv pred_ **issue** → _contract_
+_qty flv metadata pred_ **issue** → _contract_
 
 1. Pops [point](#point) `pred`.
 2. Pops [data](#data) `metadata`.

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -1448,7 +1448,7 @@ Fails if:
 _qty flv metadata pred_ **issue** → _contract_
 
 1. Pops [point](#point) `pred`.
-2. Pops [data](#data) `metadata`.
+2. Pops [data](#data-type) `metadata`.
 3. Pops [variable](#variable-type) `flv`; if the variable is detached, attaches it.
 4. Pops [variable](#variable-type) `qty`; if the variable is detached, attaches it.
 5. Creates a [value](#value-type) with variables `qty` and `flv` for quantity and flavor, respectively. 

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -1445,16 +1445,18 @@ Fails if:
 
 #### issue
 
-_qty flv pred_ **issue** → _contract_
+_qty metadata flv pred_ **issue** → _contract_
 
 1. Pops [point](#point) `pred`.
-2. Pops [variable](#variable-type) `flv`; if the variable is detached, attaches it.
-3. Pops [variable](#variable-type) `qty`; if the variable is detached, attaches it.
-4. Creates a [value](#value-type) with variables `qty` and `flv` for quantity and flavor, respectively. 
-5. Computes the _flavor_ scalar defined by the [predicate](#predicate) `pred` using the following [transcript-based](#transcript) protocol:
+2. Pops [data](#data) `metadata`.
+3. Pops [variable](#variable-type) `flv`; if the variable is detached, attaches it.
+4. Pops [variable](#variable-type) `qty`; if the variable is detached, attaches it.
+5. Creates a [value](#value-type) with variables `qty` and `flv` for quantity and flavor, respectively. 
+6. Computes the _flavor_ scalar defined by the [predicate](#predicate) `pred` using the following [transcript-based](#transcript) protocol:
     ```
     T = Transcript("ZkVM.issue")
     T.commit("predicate", pred)
+    T.commit("metadata", metadata)
     flavor = T.challenge_scalar("flavor")
     ```
 6. Checks that the `flv` has unblinded commitment to `flavor` by [deferring the point operation](#deferred-point-operations):

--- a/zkvm/src/contract.rs
+++ b/zkvm/src/contract.rs
@@ -148,9 +148,8 @@ impl Output {
                 // Data = 0x00 || LE32(len) || <bytes>
                 FrozenItem::Data(d) => {
                     encoding::write_u8(DATA_TYPE, buf);
-                    let bytes = d.to_bytes();
-                    encoding::write_u32(bytes.len() as u32, buf);
-                    encoding::write_bytes(&bytes, buf);
+                    encoding::write_u32(d.serialized_length() as u32, buf);
+                    d.encode(buf);
                 }
                 // Value = 0x01 || <32 bytes> || <32 bytes>
                 FrozenItem::Value(v) => {

--- a/zkvm/src/ops.rs
+++ b/zkvm/src/ops.rs
@@ -221,9 +221,8 @@ impl Instruction {
         match self {
             Instruction::Push(data) => {
                 write(Opcode::Push);
-                let mut bytes = data.to_bytes();
-                encoding::write_u32(bytes.len() as u32, program);
-                program.append(&mut bytes);
+                encoding::write_u32(data.serialized_length() as u32, program);
+                data.encode(program);
             }
             Instruction::Drop => write(Opcode::Drop),
             Instruction::Dup(idx) => {

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -177,13 +177,19 @@ impl Data {
             Data::Input(input) => input.encode(buf),
         };
     }
+
+    /// Returns an empty Data type.
+    pub fn empty() -> Self {
+        Data::Opaque([].to_vec())
+    }
 }
 
 impl Value {
     /// Computes a flavor as defined by the `issue` instruction from a predicate.
-    pub fn issue_flavor(predicate: &Predicate) -> Scalar {
+    pub fn issue_flavor(predicate: &Predicate, metadata: &Data) -> Scalar {
         let mut t = Transcript::new(b"ZkVM.issue");
         t.commit_bytes(b"predicate", predicate.to_point().as_bytes());
+        t.commit_bytes(b"metadata", &metadata.to_bytes());
         t.challenge_scalar(b"flavor")
     }
 }

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -186,7 +186,7 @@ impl Data {
 
 impl Default for Data {
     fn default() -> Self {
-        Data::Opaque([].to_vec())
+        Data::Opaque(Vec::new())
     }
 }
 

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -129,10 +129,15 @@ impl Data {
     }
 
     /// Converts the Data into a vector of bytes
-    pub fn to_bytes(&self) -> Vec<u8> {
-        let mut buf = Vec::with_capacity(self.serialized_length());
-        self.encode(&mut buf);
-        buf
+    pub fn to_bytes(self) -> Vec<u8> {
+        match self {
+            Data::Opaque(d) => d,
+            _ => {
+                let mut buf = Vec::with_capacity(self.serialized_length());
+                self.encode(&mut buf);
+                buf
+            }
+        }
     }
 
     /// Downcast to a Predicate type.
@@ -177,16 +182,17 @@ impl Data {
             Data::Input(input) => input.encode(buf),
         };
     }
+}
 
-    /// Returns an empty Data type.
-    pub fn empty() -> Self {
+impl Default for Data {
+    fn default() -> Self {
         Data::Opaque([].to_vec())
     }
 }
 
 impl Value {
     /// Computes a flavor as defined by the `issue` instruction from a predicate.
-    pub fn issue_flavor(predicate: &Predicate, metadata: &Data) -> Scalar {
+    pub fn issue_flavor(predicate: &Predicate, metadata: Data) -> Scalar {
         let mut t = Transcript::new(b"ZkVM.issue");
         t.commit_bytes(b"predicate", predicate.to_point().as_bytes());
         t.commit_bytes(b"metadata", &metadata.to_bytes());

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -393,7 +393,7 @@ where
         let (qty_point, _) = self.attach_variable(qty)?;
 
         self.delegate.verify_point_op(|| {
-            let flv_scalar = Value::issue_flavor(&predicate, &metadata);
+            let flv_scalar = Value::issue_flavor(&predicate, metadata);
             // flv_point == flavor·B    ->   0 == -flv_point + flv_scalar·B
             PointOp {
                 primary: Some(flv_scalar),

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -382,8 +382,10 @@ where
         Ok(())
     }
 
+    /// _pred data qty flv_ **issue** → _contract_
     fn issue(&mut self) -> Result<(), VMError> {
         let predicate = self.pop_item()?.to_data()?.to_predicate()?;
+        let metadata = self.pop_item()?.to_data()?;
         let flv = self.pop_item()?.to_variable()?;
         let qty = self.pop_item()?.to_variable()?;
 
@@ -391,7 +393,7 @@ where
         let (qty_point, _) = self.attach_variable(qty)?;
 
         self.delegate.verify_point_op(|| {
-            let flv_scalar = Value::issue_flavor(&predicate);
+            let flv_scalar = Value::issue_flavor(&predicate, &metadata);
             // flv_point == flavor·B    ->   0 == -flv_point + flv_scalar·B
             PointOp {
                 primary: Some(flv_scalar),

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -382,7 +382,7 @@ where
         Ok(())
     }
 
-    /// _pred data qty flv_ **issue** → _contract_
+    /// _qty flv data pred_ **issue** → _contract_
     fn issue(&mut self) -> Result<(), VMError> {
         let predicate = self.pop_item()?.to_data()?.to_predicate()?;
         let metadata = self.pop_item()?.to_data()?;

--- a/zkvm/tests/zkvm.rs
+++ b/zkvm/tests/zkvm.rs
@@ -32,7 +32,8 @@ impl ProgramHelper for Program {
             .var() // stack: qty-var
             .push(Commitment::unblinded(flv)) // stack: qty-var, flv
             .var() // stack: qty-var, flv-var
-            .push(issuance_pred) // stack: qty-var, flv-var, pred
+            .push(Data::empty()) // stack: qty-var, flv-var, data
+            .push(issuance_pred) // stack: qty-var, flv-var, data, pred
             .issue() // stack: issue-contract
             .push(nonce_pred) // stack: issue-contract, pred
             .nonce() // stack: issue-contract, nonce-contract
@@ -95,7 +96,7 @@ fn issuance_helper() -> (Scalar, Predicate, Scalar) {
     let gens = PedersenGens::default();
     let scalar = Scalar::from(100u64);
     let predicate = Predicate::Key((scalar * gens.B).compress().into());
-    let flavor = Value::issue_flavor(&predicate);
+    let flavor = Value::issue_flavor(&predicate, &Data::empty());
     (scalar, predicate, flavor)
 }
 
@@ -171,7 +172,7 @@ fn issue() {
         Ok(txid) => {
             // Check txid
             assert_eq!(
-                "60ab584440f5feec0b1db7a38ab4aee33d3b017ddaeedf777a48d51fbecca249",
+                "5245c74137fec1e97159a45e737c4eb8e703fb0f1d151e842351e2ab834763be",
                 hex::encode(txid.0)
             );
         }

--- a/zkvm/tests/zkvm.rs
+++ b/zkvm/tests/zkvm.rs
@@ -32,7 +32,7 @@ impl ProgramHelper for Program {
             .var() // stack: qty-var
             .push(Commitment::unblinded(flv)) // stack: qty-var, flv
             .var() // stack: qty-var, flv-var
-            .push(Data::empty()) // stack: qty-var, flv-var, data
+            .push(Data::default()) // stack: qty-var, flv-var, data
             .push(issuance_pred) // stack: qty-var, flv-var, data, pred
             .issue() // stack: issue-contract
             .push(nonce_pred) // stack: issue-contract, pred
@@ -96,7 +96,7 @@ fn issuance_helper() -> (Scalar, Predicate, Scalar) {
     let gens = PedersenGens::default();
     let scalar = Scalar::from(100u64);
     let predicate = Predicate::Key((scalar * gens.B).compress().into());
-    let flavor = Value::issue_flavor(&predicate, &Data::empty());
+    let flavor = Value::issue_flavor(&predicate, Data::default());
     (scalar, predicate, flavor)
 }
 


### PR DESCRIPTION
Adds a metadata `Data` as input to the `issue` command, embedding metadata in the flavor