### PR TITLE
zkvm: deny(missing_docs)

### DIFF
--- a/zkvm/src/constraints.rs
+++ b/zkvm/src/constraints.rs
@@ -47,7 +47,6 @@ pub enum Constraint {
     /// Disjunction of two constraints: at least one must evaluate to true.
     /// Created by `or` instruction.
     Or(Box<Constraint>, Box<Constraint>),
-
     // TBD: add `Not(Box<Constraint>)`.
 
     // no witness needed as it's normally true/false and we derive it on the fly during processing.

--- a/zkvm/src/contract.rs
+++ b/zkvm/src/contract.rs
@@ -26,6 +26,7 @@ pub enum PortableItem {
     Value(Value),
 }
 
+/// Representation of a claimed UTXO for the `input` instruction.
 #[derive(Clone, Debug)]
 pub struct Input {
     prev_output: Output,
@@ -57,9 +58,9 @@ struct FrozenValue {
 }
 
 impl Input {
-    // Creates a "frozen contract" from payload (which is a vector of (qty, flv)) and pred.
-    // Serializes the contract, and uses the serialized contract and txid to generate a utxo.
-    // Returns an Input with the contract, txid, and utxo.
+    /// Creates a "frozen contract" from payload (which is a vector of (qty, flv)) and pred.
+    /// Serializes the contract, and uses the serialized contract and txid to generate a utxo.
+    /// Returns an Input with the contract, txid, and utxo.
     pub fn new<I>(payload: I, predicate: Predicate, txid: TxID) -> Self
     where
         I: IntoIterator<Item = (Commitment, Commitment)>,

--- a/zkvm/src/errors.rs
+++ b/zkvm/src/errors.rs
@@ -112,9 +112,7 @@ pub enum VMError {
     #[fail(display = "R1CSError returned when trying to build R1CS instance")]
     R1CSError(R1CSError),
 
+    /// This error occurs when a prover expects some witness data, but it is missing.
     #[fail(display = "Item misses witness data.")]
     WitnessMissing,
-
-    #[fail(display = "Data item must be opaque")]
-    DataNotOpaque,
 }

--- a/zkvm/src/lib.rs
+++ b/zkvm/src/lib.rs
@@ -1,3 +1,6 @@
+#![deny(missing_docs)]
+//! ZkVM implementation.
+
 #[macro_use]
 extern crate failure;
 

--- a/zkvm/src/ops.rs
+++ b/zkvm/src/ops.rs
@@ -1,3 +1,6 @@
+//! Definition of all instructions in ZkVM,
+//! their codes and decoding/encoding utility functions.
+
 use core::borrow::Borrow;
 use core::mem;
 
@@ -11,7 +14,9 @@ use crate::types::Data;
 #[derive(Clone, Debug)]
 pub struct Program(Vec<Instruction>);
 
+/// A decoded instruction.
 #[derive(Clone, Debug)]
+#[allow(missing_docs)]
 pub enum Instruction {
     Push(Data), // size of the string
     Drop,
@@ -55,8 +60,10 @@ pub enum Instruction {
     Ext(u8),
 }
 
+/// A bytecode representation of the instruction.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(u8)]
+#[allow(missing_docs)]
 pub enum Opcode {
     Push = 0x00,
     Drop = 0x01,
@@ -102,10 +109,13 @@ pub enum Opcode {
 const MAX_OPCODE: u8 = 0x26;
 
 impl Opcode {
+    /// Converts the opcode to `u8`.
     pub fn to_u8(self) -> u8 {
         unsafe { mem::transmute(self) }
     }
 
+    /// Instantiates the opcode from `u8`.
+    /// Unassigned code is mapped to `None`.
     pub fn from_u8(code: u8) -> Option<Opcode> {
         if code > MAX_OPCODE {
             None
@@ -285,6 +295,7 @@ impl Instruction {
         };
     }
 
+    /// Encodes the iterator of instructions into a buffer.
     pub fn encode_program<I>(iterator: I, program: &mut Vec<u8>)
     where
         I: IntoIterator,
@@ -298,12 +309,14 @@ impl Instruction {
 
 macro_rules! def_op {
     ($func_name:ident, $op:ident) => (
+           /// Adds a `$func_name` instruction.
            pub fn $func_name(&mut self) -> &mut Program{
              self.0.push(Instruction::$op);
              self
         }
     );
     ($func_name:ident, $op:ident, $type:ty) => (
+           /// Adds a `$func_name` instruction.
            pub fn $func_name(&mut self, arg :$type) -> &mut Program{
              self.0.push(Instruction::$op(arg));
              self
@@ -377,6 +390,7 @@ impl Program {
         self
     }
 
+    /// Adds a `cloak` instruction for `m` inputs and `n` outputs.
     pub fn cloak(&mut self, m: usize, n: usize) -> &mut Program {
         self.0.push(Instruction::Cloak(m, n));
         self

--- a/zkvm/src/prover.rs
+++ b/zkvm/src/prover.rs
@@ -13,12 +13,14 @@ use crate::signature::{Signature, VerificationKey};
 use crate::txlog::{TxID, TxLog};
 use crate::vm::{Delegate, Tx, TxHeader, VM};
 
+/// Entry point for creating a transaction.
 pub struct Prover<'a, 'b> {
     signtx_keys: Vec<VerificationKey>,
     cs: r1cs::Prover<'a, 'b>,
 }
 
-pub struct ProverRun {
+/// 
+pub(crate) struct ProverRun {
     program: VecDeque<Instruction>,
 }
 
@@ -59,6 +61,9 @@ impl<'a, 'b> Delegate<r1cs::Prover<'a, 'b>> for Prover<'a, 'b> {
 }
 
 impl<'a, 'b> Prover<'a, 'b> {
+    /// Builds a transaction with a given list of instructions and a `TxHeader`.
+    /// Returns a transaction `Tx` along with its ID (`TxID`) and a transaction log (`TxLog`).
+    /// Fails if the input program is malformed, or some witness data is missing.
     pub fn build_tx<'g, F>(
         program: Vec<Instruction>,
         header: TxHeader,

--- a/zkvm/src/prover.rs
+++ b/zkvm/src/prover.rs
@@ -13,13 +13,15 @@ use crate::signature::{Signature, VerificationKey};
 use crate::txlog::{TxID, TxLog};
 use crate::vm::{Delegate, Tx, TxHeader, VM};
 
-/// Entry point for creating a transaction.
+/// This is the entry point API for creating a transaction.
+/// Prover passes the list of instructions through the VM,
+/// creates an aggregated transaction signature (for `signtx` instruction),
+/// creates a R1CS proof and returns a complete `Tx` object that can be published.
 pub struct Prover<'a, 'b> {
     signtx_keys: Vec<VerificationKey>,
     cs: r1cs::Prover<'a, 'b>,
 }
 
-/// 
 pub(crate) struct ProverRun {
     program: VecDeque<Instruction>,
 }

--- a/zkvm/src/signature.rs
+++ b/zkvm/src/signature.rs
@@ -11,9 +11,12 @@ use crate::errors::VMError;
 use crate::point_ops::PointOp;
 use crate::transcript::TranscriptProtocol;
 
+/// Verification key (aka "pubkey") is a wrapper type around a Ristretto point
+/// that lets the verifier to check the signature.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct VerificationKey(pub CompressedRistretto);
 
+/// A Schnorr signature.
 #[derive(Copy, Clone, Debug)]
 pub struct Signature {
     R: CompressedRistretto,
@@ -142,12 +145,12 @@ impl Signature {
 }
 
 impl VerificationKey {
-    // Constructs a VerificationKey from a private key.
+    /// Constructs a VerificationKey from a private key.
     pub fn from_secret(privkey: &Scalar) -> Self {
         VerificationKey(Self::from_secret_uncompressed(privkey).compress())
     }
 
-    // Constructs an uncompressed VerificationKey point from a private key.
+    /// Constructs an uncompressed VerificationKey point from a private key.
     pub(crate) fn from_secret_uncompressed(privkey: &Scalar) -> RistrettoPoint {
         let gens = PedersenGens::default();
         (privkey * gens.B)

--- a/zkvm/src/transcript.rs
+++ b/zkvm/src/transcript.rs
@@ -4,6 +4,8 @@ use curve25519_dalek::ristretto::CompressedRistretto;
 use curve25519_dalek::scalar::Scalar;
 use merlin::Transcript;
 
+/// Extension trait to the Merlin transcript API that allows committing scalars and points and
+/// generating challenges as scalars.
 pub trait TranscriptProtocol {
     /// Commit a `scalar` with the given `label`.
     fn commit_scalar(&mut self, label: &'static [u8], scalar: &Scalar);

--- a/zkvm/src/txlog.rs
+++ b/zkvm/src/txlog.rs
@@ -4,10 +4,12 @@ use merlin::Transcript;
 use crate::transcript::TranscriptProtocol;
 use crate::vm::TxHeader;
 
+/// Transaction log. `TxLog` is a type alias for `Vec<Entry>`.
 pub type TxLog = Vec<Entry>;
 
 /// Entry in a transaction log
 #[derive(Clone, PartialEq, Debug)]
+#[allow(missing_docs)]
 pub enum Entry {
     Header(TxHeader),
     Issue(CompressedRistretto, CompressedRistretto),

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -14,33 +14,61 @@ use crate::predicate::Predicate;
 use crate::scalar_witness::ScalarWitness;
 use crate::transcript::TranscriptProtocol;
 
+/// An item on a VM stack.
 #[derive(Debug)]
 pub enum Item {
+    /// A data item.
     Data(Data),
+
+    /// A contract.
     Contract(Contract),
+
+    /// A value type.
     Value(Value),
+
+    /// A wide value type.
     WideValue(WideValue),
+
+    /// A variable type.
     Variable(Variable),
+
+    /// An expression type.
     Expression(Expression),
+
+    /// A constraint type.
     Constraint(Constraint),
 }
 
+/// A data item.
 #[derive(Clone, Debug)]
 pub enum Data {
+    /// Opaque data item.
     Opaque(Vec<u8>),
+
+    /// A program (list of instructions).
     Program(Vec<Instruction>),
+
+    /// A predicate.
     Predicate(Box<Predicate>),
+
+    /// A Pedersen commitment.
     Commitment(Box<Commitment>),
+
+    /// A scalar witness (scalar or integer).
     Scalar(Box<ScalarWitness>),
+
+    /// An input object (claimed UTXO).
     Input(Box<Input>),
 }
 
+/// A value type.
 #[derive(Debug)]
 pub struct Value {
     pub(crate) qty: Variable,
     pub(crate) flv: Variable,
 }
 
+/// A wide value type (for negative values created by `borrow`).
 #[derive(Debug)]
 pub struct WideValue {
     pub(crate) r1cs_qty: r1cs::Variable,
@@ -49,7 +77,7 @@ pub struct WideValue {
 }
 
 impl Item {
-    // Downcasts to Data type
+    /// Downcasts item to `Data` type.
     pub fn to_data(self) -> Result<Data, VMError> {
         match self {
             Item::Data(x) => Ok(x),
@@ -57,7 +85,7 @@ impl Item {
         }
     }
 
-    // Downcasts to Contract type
+    /// Downcasts item to `Contract` type.
     pub fn to_contract(self) -> Result<Contract, VMError> {
         match self {
             Item::Contract(c) => Ok(c),
@@ -65,7 +93,7 @@ impl Item {
         }
     }
 
-    // Downcasts to Value type
+    /// Downcasts item to `Value` type.
     pub fn to_value(self) -> Result<Value, VMError> {
         match self {
             Item::Value(v) => Ok(v),
@@ -73,7 +101,7 @@ impl Item {
         }
     }
 
-    // Downcasts to WideValue type (Value is NOT casted to WideValue)
+    /// Downcasts item to `WideValue` type (Value is NOT casted to WideValue).
     pub fn to_wide_value(self) -> Result<WideValue, VMError> {
         match self {
             Item::WideValue(w) => Ok(w),
@@ -81,7 +109,7 @@ impl Item {
         }
     }
 
-    // Downcasts to Variable type
+    /// Downcasts item to `Variable` type.
     pub fn to_variable(self) -> Result<Variable, VMError> {
         match self {
             Item::Variable(v) => Ok(v),
@@ -89,7 +117,7 @@ impl Item {
         }
     }
 
-    // Downcasts to Expression type (Variable is NOT casted to Expression)
+    /// Downcasts item to `Expression` type (Variable is NOT casted to Expression).
     pub fn to_expression(self) -> Result<Expression, VMError> {
         match self {
             Item::Expression(expr) => Ok(expr),
@@ -97,7 +125,7 @@ impl Item {
         }
     }
 
-    // Downcasts to Constraint type
+    /// Downcasts item to `Constraint` type.
     pub fn to_constraint(self) -> Result<Constraint, VMError> {
         match self {
             Item::Constraint(c) => Ok(c),
@@ -105,7 +133,7 @@ impl Item {
         }
     }
 
-    // Downcasts to a portable type
+    /// Downcasts item to a portable type (`Data` or `Value`).
     pub fn to_portable(self) -> Result<PortableItem, VMError> {
         match self {
             Item::Data(x) => Ok(PortableItem::Data(x)),
@@ -128,7 +156,9 @@ impl Data {
         }
     }
 
-    /// Converts the Data into a vector of bytes
+    /// Converts the Data item into a vector of bytes.
+    /// Opaque item is converted without extra allocations,
+    /// non-opaque item is encoded to a newly allocated buffer.
     pub fn to_bytes(self) -> Vec<u8> {
         match self {
             Data::Opaque(d) => d,
@@ -140,7 +170,7 @@ impl Data {
         }
     }
 
-    /// Downcast to a Predicate type.
+    /// Downcast the data item to a `Predicate` type.
     pub fn to_predicate(self) -> Result<Predicate, VMError> {
         match self {
             Data::Opaque(data) => {
@@ -152,6 +182,7 @@ impl Data {
         }
     }
 
+    /// Downcast the data item to a `Commitment` type.
     pub fn to_commitment(self) -> Result<Commitment, VMError> {
         match self {
             Data::Opaque(data) => {
@@ -163,6 +194,7 @@ impl Data {
         }
     }
 
+    /// Downcast the data item to an `Input` type.
     pub fn to_input(self) -> Result<Input, VMError> {
         match self {
             Data::Opaque(data) => Input::from_bytes(data),
@@ -171,7 +203,7 @@ impl Data {
         }
     }
 
-    /// Encodes blinded Data values.
+    /// Encodes the data item to a byte buffer.
     pub fn encode(&self, buf: &mut Vec<u8>) {
         match self {
             Data::Opaque(x) => buf.extend_from_slice(x),

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -203,7 +203,7 @@ impl Data {
         }
     }
 
-    /// Encodes the data item to a byte buffer.
+    /// Encodes the data item to an opaque bytestring.
     pub fn encode(&self, buf: &mut Vec<u8>) {
         match self {
             Data::Opaque(x) => buf.extend_from_slice(x),

--- a/zkvm/src/verifier.rs
+++ b/zkvm/src/verifier.rs
@@ -13,6 +13,11 @@ use crate::signature::VerificationKey;
 
 use crate::vm::{Delegate, Tx, VerifiedTx, VM};
 
+/// This is the entry point API for verifying a transaction.
+/// Verifier passes the `Tx` object through the VM,
+/// verifies an aggregated transaction signature (see `signtx` instruction),
+/// verifies a R1CS proof and returns a `VerifiedTx` with the log of changes
+/// to be applied to the blockchain state.
 pub struct Verifier<'a, 'b> {
     signtx_keys: Vec<VerificationKey>,
     deferred_operations: Vec<PointOp>,
@@ -68,6 +73,8 @@ impl<'a, 'b> Delegate<r1cs::Verifier<'a, 'b>> for Verifier<'a, 'b> {
 }
 
 impl<'a, 'b> Verifier<'a, 'b> {
+    /// Verifies the `Tx` object by executing the VM and returns the `VerifiedTx`.
+    /// Returns an error if the program is malformed or any of the proofs are not valid.
     pub fn verify_tx<'g>(tx: Tx, bp_gens: &'g BulletproofGens) -> Result<VerifiedTx, VMError> {
         let mut r1cs_transcript = Transcript::new(b"ZkVM.r1cs");
         let pc_gens = PedersenGens::default();

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -51,17 +51,17 @@ pub struct Tx {
 
 /// Represents a verified transaction: a txid and a list of state updates.
 pub struct VerifiedTx {
-    /// Header metadata
+    /// Transaction header
     pub header: TxHeader,
 
     /// Transaction ID
     pub id: TxID,
 
-    // List of inputs, outputs and nonces to be inserted/deleted in the blockchain state.
+    /// Transaction log: a list of changes to the blockchain state (UTXOs to delete/insert, etc.)
     pub log: TxLog,
 }
 
-pub struct VM<'d, CS, D>
+pub(crate) struct VM<'d, CS, D>
 where
     CS: r1cs::ConstraintSystem,
     D: Delegate<CS>,
@@ -88,7 +88,7 @@ where
     variable_commitments: Vec<VariableCommitment>,
 }
 
-pub trait Delegate<CS: r1cs::ConstraintSystem> {
+pub(crate) trait Delegate<CS: r1cs::ConstraintSystem> {
     type RunType;
 
     /// Adds a Commitment to the underlying constraint system, producing a high-level variable


### PR DESCRIPTION
This enforces presence of documentation for all items (modules, types, traits, methods, constants) throughout ZkVM.

It allows opt-out via per-item `#[allow(missing_docs)]`. I use it in two places for lists of opcodes and instructions where explicit documentation is not more helpful than the name of an instruction itself: the reader is supposed to check the specification instead.

Closes #114.