### PR TITLE
slidechain: check for export tx more robustly

### DIFF
--- a/slidechain/export.go
+++ b/slidechain/export.go
@@ -52,9 +52,6 @@ const baseFee = 100
 const (
 	custodianSigCheckerFmt = `txid x"%x" get 0 checksig verify`
 
-	// TODO(debnil): Add a log statement in this contract, and check for
-	// its existence, with appropriate seed, in the watchExports goroutine.
-	// This more robustly checks for the export tx.
 	exportContract1Fmt = `
 	              #  con stack                arg stack              log
 	              #  ---------                ---------              ---

--- a/slidechain/export.go
+++ b/slidechain/export.go
@@ -59,6 +59,7 @@ const (
 	              #  con stack                arg stack              log
 	              #  ---------                ---------              ---
 	              #                           json, value, {exporter}       
+	'' log        #                                                  {L,...}
 	get get get   #  {exporter}, value, json                                  
 	x'%x' output  #                                                  {O,...}
 `

--- a/slidechain/watch.go
+++ b/slidechain/watch.go
@@ -145,9 +145,9 @@ func (c *Custodian) watchExports(ctx context.Context) {
 				continue
 			}
 
-			exportDataLogItem := tx.Log[1]
+			exportDataInfoItem := tx.Log[1]
 			var info pegOut
-			err := json.Unmarshal(exportDataLogItem[2].(txvm.Bytes), &info)
+			err := json.Unmarshal(exportDataInfoItem[2].(txvm.Bytes), &info)
 			if err != nil {
 				continue
 			}

--- a/slidechain/watch.go
+++ b/slidechain/watch.go
@@ -141,7 +141,7 @@ func (c *Custodian) watchExports(ctx context.Context) {
 			if exportSeedLogItem[0].(txvm.Bytes)[0] != txvm.LogCode {
 				continue
 			}
-			if bytes.Compare(exportSeedLogItem[1].(txvm.Bytes), exportContract1Seed[:]) != 0 {
+			if !bytes.Equal(exportSeedLogItem[1].(txvm.Bytes), exportContract1Seed[:]) {
 				continue
 			}
 

--- a/slidechain/watch.go
+++ b/slidechain/watch.go
@@ -1,6 +1,7 @@
 package slidechain
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -121,7 +122,7 @@ func (c *Custodian) watchExports(ctx context.Context) {
 			// Confirm that its input, log, and output entries are as expected.
 			// If so, look for a specially formatted log ("L") entry
 			// that specifies the Stellar asset code to peg out and the Stellar recipient account ID.
-			if len(tx.Log) != 4 && len(tx.Log) != 6 {
+			if len(tx.Log) != 5 && len(tx.Log) != 7 {
 				continue
 			}
 			if tx.Log[0][0].(txvm.Bytes)[0] != txvm.InputCode {
@@ -136,9 +137,17 @@ func (c *Custodian) watchExports(ctx context.Context) {
 				continue
 			}
 
-			logItem := tx.Log[1]
+			exportSeedLogItem := tx.Log[len(tx.Log)-3]
+			if exportSeedLogItem[0].(txvm.Bytes)[0] != txvm.LogCode {
+				continue
+			}
+			if bytes.Compare(exportSeedLogItem[1].(txvm.Bytes), exportContract1Seed[:]) != 0 {
+				continue
+			}
+
+			exportDataLogItem := tx.Log[1]
 			var info pegOut
-			err := json.Unmarshal(logItem[2].(txvm.Bytes), &info)
+			err := json.Unmarshal(exportDataLogItem[2].(txvm.Bytes), &info)
 			if err != nil {
 				continue
 			}


### PR DESCRIPTION
Checks for the export transaction more robustly. A log statement is added to the called export contract, and the goroutine watching for the export transaction also checks for the existence of the accompanying tuple in the transaction log.