### PR TITLE
zkvm: remove blinding protocol + simplify VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ with **cloaked assets** and **zero-knowledge smart contracts**.
 ### [Spacesuit](spacesuit)
 
 Interstellar’s implementation of _Cloak_, a confidential assets protocol
-based on the [Bulletproofs](http://doc.dalek.rs/bulletproofs/index.html) zero-knowledge circuit proof system.
+based on the [Bulletproofs](https://doc.dalek.rs/bulletproofs/index.html) zero-knowledge circuit proof system.
 
 * [Spacesuit README](spacesuit/README.md)
 * [Cloak specification](spacesuit/spec.md)

--- a/token/src/token.rs
+++ b/token/src/token.rs
@@ -1,5 +1,5 @@
 use curve25519_dalek::scalar::Scalar;
-use zkvm::{Commitment, Data, Input, Output, Predicate, Program, TxID, Value};
+use zkvm::{Commitment, Contract, Data, Input, Predicate, Program, TxID, Value};
 
 /// Represents a ZkVM Token with unique flavor and embedded
 /// metadata protected by a user-supplied Predicate.
@@ -55,7 +55,7 @@ impl Token {
     /// TBD: accept a qty/Token pairing to retire.
     pub fn retire<'a>(
         program: &'a mut Program,
-        prev_output: Output,
+        prev_output: Contract,
         txid: TxID,
     ) -> &'a mut Program {
         program

--- a/zkvm/docs/zkvm-api.md
+++ b/zkvm/docs/zkvm-api.md
@@ -42,7 +42,8 @@ zkvm-spec.md#left) and [`right`](zkvm-spec.md#right) instructions.
 
 ### Variables
 
-Variables are represented as indices into the commitments stored within the VM state. VM manages the "attached" state of the variables to permit replacing the commitments via [`reblind`](zkvm-spec.md#reblind). The secret assignments for the variables are stored within the _commitment witnesses_ as [described above](#commitments).
+Variables are represented as type-wrappers around Pedersen commitments.
+The secret assignments for the variables are stored within the _commitment witnesses_ as [described above](#commitments).
 
 ### Expressions
 

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -961,29 +961,29 @@ Code | Instruction                | Stack diagram                              |
 0x0f | [`and`](#and)              | _constr1 constr2_ → _constr3_              |
 0x10 | [`or`](#or)                | _constr1 constr2_ → _constr3_              |
 0x11 | [`verify`](#verify)        |      _constraint_ → ø                      | Modifies [CS](#constraint-system) 
-0x14 | [`unblind`](#unblind)      |        _v V expr_ → _var_                  | Modifies [CS](#constraint-system), [Defers point ops](#deferred-point-operations)
+0x12 | [`unblind`](#unblind)      |        _v V expr_ → _var_                  | Modifies [CS](#constraint-system), [Defers point ops](#deferred-point-operations)
  |                                |                                            |
  |     [**Values**](#value-instructions)              |                        |
-0x15 | [`issue`](#issue)          |    _qty flv data pred_ → _contract_        | Modifies [CS](#constraint-system), [tx log](#transaction-log), [defers point ops](#deferred-point-operations)
-0x16 | [`borrow`](#borrow)        |         _qty flv_ → _–V +V_                | Modifies [CS](#constraint-system)
-0x17 | [`retire`](#retire)        |           _value_ → ø                      | Modifies [CS](#constraint-system), [tx log](#transaction-log)
-0x18 | [`qty`](#qty)              |           _value_ → _value qtyvar_         |
-0x19 | [`flavor`](#flavor)        |           _value_ → _value flavorvar_      |
-0x1a | [`cloak:m:n`](#cloak)      | _widevalues commitments_ → _values_        | Modifies [CS](#constraint-system)
-0x1b | [`import`](#import)        |   _proof qty flv_ → _value_                | Modifies [CS](#constraint-system), [tx log](#transaction-log), [defers point ops](#deferred-point-operations)
-0x1c | [`export`](#export)        |       _value ???_ → ø                      | Modifies [CS](#constraint-system), [tx log](#transaction-log)
+0x13 | [`issue`](#issue)          |    _qty flv data pred_ → _contract_        | Modifies [CS](#constraint-system), [tx log](#transaction-log), [defers point ops](#deferred-point-operations)
+0x14 | [`borrow`](#borrow)        |         _qty flv_ → _–V +V_                | Modifies [CS](#constraint-system)
+0x15 | [`retire`](#retire)        |           _value_ → ø                      | Modifies [CS](#constraint-system), [tx log](#transaction-log)
+0x16 | [`qty`](#qty)              |           _value_ → _value qtyvar_         |
+0x17 | [`flavor`](#flavor)        |           _value_ → _value flavorvar_      |
+0x18 | [`cloak:m:n`](#cloak)      | _widevalues commitments_ → _values_        | Modifies [CS](#constraint-system)
+0x19 | [`import`](#import)        |   _proof qty flv_ → _value_                | Modifies [CS](#constraint-system), [tx log](#transaction-log), [defers point ops](#deferred-point-operations)
+0x1a | [`export`](#export)        |       _value ???_ → ø                      | Modifies [CS](#constraint-system), [tx log](#transaction-log)
  |                                |                                            |
  |     [**Contracts**](#contract-instructions)        |                        |
-0x1d | [`input`](#input)          |           _input_ → _contract_             | Modifies [tx log](#transaction-log)
-0x1e | [`output:k`](#output)      |   _items... pred_ → ø                      | Modifies [tx log](#transaction-log)
-0x1f | [`contract:k`](#contract)  |   _items... pred_ → _contract_             | 
-0x20 | [`nonce`](#nonce)          |            _pred_ → _contract_             | Modifies [tx log](#transaction-log)
-0x21 | [`log`](#log)              |            _data_ → ø                      | Modifies [tx log](#transaction-log)
-0x22 | [`signtx`](#signtx)        |        _contract_ → _results..._           | Modifies [deferred verification keys](#transaction-signature)
-0x23 | [`call`](#call)            |   _contract prog_ → _results..._           | [Defers point operations](#deferred-point-operations)
-0x24 | [`left`](#left)            |    _contract A B_ → _contract’_            | [Defers point operations](#deferred-point-operations)
-0x25 | [`right`](#right)          |    _contract A B_ → _contract’_            | [Defers point operations](#deferred-point-operations)
-0x26 | [`delegate`](#delegate)    |_contract prog sig_ → _results..._          | [Defers point operations](#deferred-point-operations)
+0x1b | [`input`](#input)          |           _input_ → _contract_             | Modifies [tx log](#transaction-log)
+0x1c | [`output:k`](#output)      |   _items... pred_ → ø                      | Modifies [tx log](#transaction-log)
+0x1d | [`contract:k`](#contract)  |   _items... pred_ → _contract_             | 
+0x1e | [`nonce`](#nonce)          |            _pred_ → _contract_             | Modifies [tx log](#transaction-log)
+0x1f | [`log`](#log)              |            _data_ → ø                      | Modifies [tx log](#transaction-log)
+0x20 | [`signtx`](#signtx)        |        _contract_ → _results..._           | Modifies [deferred verification keys](#transaction-signature)
+0x21 | [`call`](#call)            |   _contract prog_ → _results..._           | [Defers point operations](#deferred-point-operations)
+0x22 | [`left`](#left)            |    _contract A B_ → _contract’_            | [Defers point operations](#deferred-point-operations)
+0x23 | [`right`](#right)          |    _contract A B_ → _contract’_            | [Defers point operations](#deferred-point-operations)
+0x24 | [`delegate`](#delegate)    |_contract prog sig_ → _results..._          | [Defers point operations](#deferred-point-operations)
   —  | [`ext`](#ext)              |                 ø → ø                      | Fails if [extension flag](#vm-state) is not set.
 
 

--- a/zkvm/src/constraints.rs
+++ b/zkvm/src/constraints.rs
@@ -14,10 +14,10 @@ use crate::scalar_witness::ScalarWitness;
 /// Variable represents a high-level R1CS variable specified by its
 /// Pedersen commitment. In ZkVM variables are actually indices to a list
 /// of stored commitments to permit commitment reblinding (see `reblind` instruction).
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct Variable {
-    pub(crate) index: usize,
-    // the witness is located indirectly in vm::VariableCommitment
+    /// TBD: maybe do this as a subtype of the Expression
+    pub(crate) commitment: Commitment,
 }
 
 /// Expression is a linear combination of high-level variables (`var`),
@@ -158,6 +158,15 @@ impl Commitment {
         match self {
             Commitment::Closed(_) => None,
             Commitment::Open(w) => Some((w.value, w.blinding)),
+        }
+    }
+
+    /// Returns the committed scalar or integer, without the blinding factor.
+    /// If the witness is missing, returns None.
+    pub fn assignment(&self) -> Option<ScalarWitness> {
+        match self {
+            Commitment::Closed(_) => None,
+            Commitment::Open(w) => Some(w.value),
         }
     }
 }

--- a/zkvm/src/lib.rs
+++ b/zkvm/src/lib.rs
@@ -21,7 +21,7 @@ mod verifier;
 mod vm;
 
 pub use self::constraints::{Commitment, Constraint, Expression, Variable};
-pub use self::contract::{FrozenItem, FrozenValue, Input, Output};
+pub use self::contract::{Contract, Input, PortableItem};
 pub use self::errors::VMError;
 pub use self::ops::{Instruction, Opcode, Program};
 pub use self::predicate::Predicate;

--- a/zkvm/src/ops.rs
+++ b/zkvm/src/ops.rs
@@ -36,8 +36,6 @@ pub enum Instruction {
     And,
     Or,
     Verify,
-    Blind,
-    Reblind,
     Unblind,
     Issue,
     Borrow,
@@ -83,30 +81,28 @@ pub enum Opcode {
     And = 0x0f,
     Or = 0x10,
     Verify = 0x11,
-    Blind = 0x12,
-    Reblind = 0x13,
-    Unblind = 0x14,
-    Issue = 0x15,
-    Borrow = 0x16,
-    Retire = 0x17,
-    Qty = 0x18,
-    Flavor = 0x19,
-    Cloak = 0x1a,
-    Import = 0x1b,
-    Export = 0x1c,
-    Input = 0x1d,
-    Output = 0x1e,
-    Contract = 0x1f,
-    Nonce = 0x20,
-    Log = 0x21,
-    Signtx = 0x22,
-    Call = 0x23,
-    Left = 0x24,
-    Right = 0x25,
+    Unblind = 0x12,
+    Issue = 0x13,
+    Borrow = 0x14,
+    Retire = 0x15,
+    Qty = 0x16,
+    Flavor = 0x17,
+    Cloak = 0x18,
+    Import = 0x19,
+    Export = 0x1a,
+    Input = 0x1b,
+    Output = 0x1c,
+    Contract = 0x1d,
+    Nonce = 0x1e,
+    Log = 0x1f,
+    Signtx = 0x20,
+    Call = 0x21,
+    Left = 0x22,
+    Right = 0x23,
     Delegate = MAX_OPCODE,
 }
 
-const MAX_OPCODE: u8 = 0x26;
+const MAX_OPCODE: u8 = 0x24;
 
 impl Opcode {
     /// Converts the opcode to `u8`.
@@ -190,8 +186,6 @@ impl Instruction {
             Opcode::And => Ok(Instruction::And),
             Opcode::Or => Ok(Instruction::Or),
             Opcode::Verify => Ok(Instruction::Verify),
-            Opcode::Blind => Ok(Instruction::Blind),
-            Opcode::Reblind => Ok(Instruction::Reblind),
             Opcode::Unblind => Ok(Instruction::Unblind),
             Opcode::Issue => Ok(Instruction::Issue),
             Opcode::Borrow => Ok(Instruction::Borrow),
@@ -260,8 +254,6 @@ impl Instruction {
             Instruction::And => write(Opcode::And),
             Instruction::Or => write(Opcode::Or),
             Instruction::Verify => write(Opcode::Verify),
-            Instruction::Blind => write(Opcode::Blind),
-            Instruction::Reblind => write(Opcode::Reblind),
             Instruction::Unblind => write(Opcode::Unblind),
             Instruction::Issue => write(Opcode::Issue),
             Instruction::Borrow => write(Opcode::Borrow),
@@ -328,7 +320,6 @@ impl Program {
     def_op!(add, Add);
     def_op!(alloc, Alloc);
     def_op!(and, And);
-    def_op!(blind, Blind);
     def_op!(borrow, Borrow);
     def_op!(call, Call);
     def_op!(r#const, Const);
@@ -354,7 +345,6 @@ impl Program {
     def_op!(output, Output, usize);
     def_op!(qty, Qty);
     def_op!(range, Range, u8);
-    def_op!(reblind, Reblind);
     def_op!(retire, Retire);
     def_op!(right, Right);
     def_op!(roll, Roll, usize);

--- a/zkvm/src/txlog.rs
+++ b/zkvm/src/txlog.rs
@@ -1,7 +1,7 @@
 use curve25519_dalek::ristretto::CompressedRistretto;
 use merlin::Transcript;
 
-use crate::contract::Output;
+use crate::contract::Contract;
 use crate::transcript::TranscriptProtocol;
 use crate::vm::TxHeader;
 
@@ -17,7 +17,7 @@ pub enum Entry {
     Retire(CompressedRistretto, CompressedRistretto),
     Input(UTXO),
     Nonce(CompressedRistretto, u64),
-    Output(Output),
+    Output(Contract),
     Data(Vec<u8>),
     Import, // TBD: parameters
     Export, // TBD: parameters
@@ -101,8 +101,8 @@ impl Entry {
                 t.commit_point(b"nonce.p", &pred);
                 t.commit_u64(b"nonce.t", *maxtime);
             }
-            Entry::Output(outstruct) => {
-                t.commit_bytes(b"output", &outstruct.to_bytes());
+            Entry::Output(contract) => {
+                t.commit_bytes(b"output", &contract.to_bytes());
             }
             Entry::Data(data) => {
                 t.commit_bytes(b"data", data);

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -61,11 +61,15 @@ pub enum Data {
     Input(Box<Input>),
 }
 
-/// A value type.
-#[derive(Debug)]
+/// Represents a value of an issued asset in the VM.
+/// Note: values do not necessarily have open commitments. Some can be reblinded,
+/// others can be passed-through to an output without going through `cloak` and the constraint system.
+#[derive(Clone, Debug)]
 pub struct Value {
-    pub(crate) qty: Variable,
-    pub(crate) flv: Variable,
+    /// Commitment to value's quantity
+    pub qty: Commitment,
+    /// Commitment to value's flavor
+    pub flv: Commitment,
 }
 
 /// A wide value type (for negative values created by `borrow`).
@@ -237,6 +241,16 @@ impl Value {
         t.commit_bytes(b"predicate", predicate.to_point().as_bytes());
         t.commit_bytes(b"metadata", &metadata.to_bytes());
         t.challenge_scalar(b"flavor")
+    }
+
+    /// Returns a (qty,flavor) assignment to a value, or None if both fields are unassigned.
+    /// Fails if the assigment is inconsistent.
+    pub(crate) fn assignment(&self) -> Result<Option<(SignedInteger, Scalar)>, VMError> {
+        match (self.qty.assignment(), self.flv.assignment()) {
+            (None, None) => Ok(None),
+            (Some(ScalarWitness::Integer(q)), Some(ScalarWitness::Scalar(f))) => Ok(Some((q, f))),
+            (_, _) => return Err(VMError::InconsistentWitness),
+        }
     }
 }
 

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -4,7 +4,6 @@ use curve25519_dalek::ristretto::CompressedRistretto;
 use curve25519_dalek::scalar::Scalar;
 use merlin::Transcript;
 use spacesuit;
-use spacesuit::SignedInteger;
 use std::iter::FromIterator;
 use std::mem;
 
@@ -87,7 +86,6 @@ where
     current_run: D::RunType,
     run_stack: Vec<D::RunType>,
     txlog: TxLog,
-    variable_commitments: Vec<VariableCommitment>,
 }
 
 pub(crate) trait Delegate<CS: r1cs::ConstraintSystem> {
@@ -121,21 +119,6 @@ pub(crate) trait Delegate<CS: r1cs::ConstraintSystem> {
     fn new_run(&self, prog: Data) -> Result<Self::RunType, VMError>;
 }
 
-/// And indirect reference to a high-level variable within a constraint system.
-/// Variable types store index of such commitments that allows replacing them.
-#[derive(Debug)]
-pub struct VariableCommitment {
-    /// Pedersen commitment to a variable
-    commitment: Commitment,
-
-    /// Attached/detached state
-    /// None - if the variable is not attached to the CS yet,
-    /// so its commitment is replaceable via `reblind`.
-    /// Some - if variable is attached to the CS yet and has an index in CS,
-    /// so its commitment is no longer replaceable via `reblind`.
-    variable: Option<r1cs::Variable>,
-}
-
 impl<'d, CS, D> VM<'d, CS, D>
 where
     CS: r1cs::ConstraintSystem,
@@ -153,7 +136,6 @@ where
             current_run: run,
             run_stack: Vec::new(),
             txlog: vec![Entry::Header(header)],
-            variable_commitments: Vec::new(),
         }
     }
 
@@ -361,8 +343,8 @@ where
     }
 
     fn var(&mut self) -> Result<(), VMError> {
-        let comm = self.pop_item()?.to_data()?.to_commitment()?;
-        let v = self.commitment_to_variable(comm);
+        let commitment = self.pop_item()?.to_data()?.to_commitment()?;
+        let v = Variable { commitment };
         self.push_item(v);
         Ok(())
     }
@@ -403,8 +385,8 @@ where
         let flv = self.pop_item()?.to_variable()?;
         let qty = self.pop_item()?.to_variable()?;
 
-        let (flv_point, _) = self.attach_variable(flv)?;
-        let (qty_point, _) = self.attach_variable(qty)?;
+        let (flv_point, _) = self.delegate.commit_variable(&flv.commitment)?;
+        let (qty_point, _) = self.delegate.commit_variable(&qty.commitment)?;
 
         self.delegate.verify_point_op(|| {
             let flv_scalar = Value::issue_flavor(&predicate, metadata);
@@ -416,7 +398,10 @@ where
             }
         })?;
 
-        let value = Value { qty, flv };
+        let value = Value {
+            qty: qty.commitment.clone(),
+            flv: flv.commitment,
+        };
 
         let qty_expr = self.variable_to_expression(qty)?;
         self.add_range_proof(64, qty_expr)?;
@@ -434,16 +419,15 @@ where
 
     fn retire(&mut self) -> Result<(), VMError> {
         let value = self.pop_item()?.to_value()?;
-        let qty = self.variable_to_commitment(value.qty);
-        let flv = self.variable_to_commitment(value.flv);
-        self.txlog.push(Entry::Retire(qty.into(), flv.into()));
+        self.txlog
+            .push(Entry::Retire(value.qty.into(), value.flv.into()));
         Ok(())
     }
 
     /// _input_ **input** → _contract_
     fn input(&mut self) -> Result<(), VMError> {
         let input = self.pop_item()?.to_data()?.to_input()?;
-        let (contract, utxo) = input.unfreeze(|c| self.commitment_to_variable(c));
+        let (contract, utxo) = input.unfreeze();
         self.push_item(contract);
         self.txlog.push(Entry::Input(utxo));
         self.unique = true;
@@ -453,8 +437,7 @@ where
     /// _items... predicate_ **output:_k_** → ø
     fn output(&mut self, k: usize) -> Result<(), VMError> {
         let contract = self.pop_contract(k)?;
-        let frozen_contract = contract.freeze(|v| self.variable_to_commitment(v));
-        self.txlog.push(Entry::Output(frozen_contract));
+        self.txlog.push(Entry::Output(contract));
         Ok(())
     }
 
@@ -495,20 +478,18 @@ where
             return Err(VMError::StackUnderflow);
         }
 
-        let mut output_values: Vec<Value> = Vec::with_capacity(2 * n);
+        let mut output_values: Vec<Value> = Vec::with_capacity(n);
 
         let mut cloak_ins: Vec<spacesuit::AllocatedValue> = Vec::with_capacity(m);
-        let mut cloak_outs: Vec<spacesuit::AllocatedValue> = Vec::with_capacity(2 * n);
+        let mut cloak_outs: Vec<spacesuit::AllocatedValue> = Vec::with_capacity(n);
 
         // Make cloak outputs and output values using (qty,flv) commitments
         for _ in 0..n {
             let flv = self.pop_item()?.to_data()?.to_commitment()?;
             let qty = self.pop_item()?.to_data()?.to_commitment()?;
 
-            let flv = self.commitment_to_variable(flv);
-            let qty = self.commitment_to_variable(qty);
-
             let value = Value { qty, flv };
+
             let cloak_value = self.value_to_cloak_value(&value)?;
 
             // insert in the same order as they are on stack (the deepest item will be at index 0)
@@ -659,46 +640,14 @@ where
         self.stack.push(item.into())
     }
 
-    fn commitment_to_variable(&mut self, commitment: Commitment) -> Variable {
-        let index = self.variable_commitments.len();
-
-        self.variable_commitments.push(VariableCommitment {
-            commitment: commitment,
-            variable: None,
-        });
-        Variable { index }
-    }
-
-    fn variable_to_commitment(&self, var: Variable) -> Commitment {
-        self.variable_commitments[var.index].commitment.clone()
-    }
-
-    fn attach_variable(
-        &mut self,
-        var: Variable,
-    ) -> Result<(CompressedRistretto, r1cs::Variable), VMError> {
-        // This subscript never fails because the variable is created only via `commitment_to_variable`.
-        let v_com = &self.variable_commitments[var.index];
-        match v_com.variable {
-            Some(v) => Ok((v_com.commitment.to_point(), v)),
-            None => {
-                let (point, r1cs_var) = self.delegate.commit_variable(&v_com.commitment)?;
-                self.variable_commitments[var.index].variable = Some(r1cs_var);
-                Ok((point, r1cs_var))
-            }
-        }
-    }
-
     fn value_to_cloak_value(
         &mut self,
         value: &Value,
     ) -> Result<spacesuit::AllocatedValue, VMError> {
         Ok(spacesuit::AllocatedValue {
-            q: self.attach_variable(value.qty)?.1,
-            f: self.attach_variable(value.flv)?.1,
-            assignment: self
-                .value_witness(&value)?
-                .map(|(q, f)| spacesuit::Value { q, f }),
+            q: self.delegate.commit_variable(&value.qty)?.1,
+            f: self.delegate.commit_variable(&value.flv)?.1,
+            assignment: value.assignment()?.map(|(q, f)| spacesuit::Value { q, f }),
         })
     }
 
@@ -716,9 +665,9 @@ where
     fn item_to_wide_value(&mut self, item: Item) -> Result<WideValue, VMError> {
         match item {
             Item::Value(value) => Ok(WideValue {
-                r1cs_qty: self.attach_variable(value.qty)?.1,
-                r1cs_flv: self.attach_variable(value.flv)?.1,
-                witness: self.value_witness(&value)?,
+                r1cs_qty: self.delegate.commit_variable(&value.qty)?.1,
+                r1cs_flv: self.delegate.commit_variable(&value.flv)?.1,
+                witness: value.assignment()?,
             }),
             Item::WideValue(w) => Ok(w),
             _ => Err(VMError::TypeNotWideValue),
@@ -726,32 +675,12 @@ where
     }
 
     fn variable_to_expression(&mut self, var: Variable) -> Result<Expression, VMError> {
-        let (_, r1cs_var) = self.attach_variable(var)?;
+        let (_, r1cs_var) = self.delegate.commit_variable(&var.commitment)?;
 
         Ok(Expression::LinearCombination(
             vec![(r1cs_var, Scalar::one())],
-            self.variable_assignment(var),
+            var.commitment.assignment(),
         ))
-    }
-
-    /// Returns Ok(Some((qty,flv))) assignment pair if it's missing or consistent.
-    /// Return Err if the witness is present, but is inconsistent.
-    fn value_witness(&mut self, value: &Value) -> Result<Option<(SignedInteger, Scalar)>, VMError> {
-        match (
-            self.variable_assignment(value.qty),
-            self.variable_assignment(value.flv),
-        ) {
-            (Some(ScalarWitness::Integer(q)), Some(ScalarWitness::Scalar(f))) => Ok(Some((q, f))),
-            (None, None) => Ok(None),
-            (_, _) => return Err(VMError::InconsistentWitness),
-        }
-    }
-
-    fn variable_assignment(&mut self, var: Variable) -> Option<ScalarWitness> {
-        self.variable_commitments[var.index]
-            .commitment
-            .witness()
-            .map(|(content, _)| content)
     }
 
     fn continue_with_program(&mut self, prog: Data) -> Result<(), VMError> {

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -196,8 +196,6 @@ where
                 Instruction::And => self.and()?,
                 Instruction::Or => self.or()?,
                 Instruction::Verify => self.verify()?,
-                Instruction::Blind => unimplemented!(),
-                Instruction::Reblind => unimplemented!(),
                 Instruction::Unblind => unimplemented!(),
                 Instruction::Issue => self.issue()?,
                 Instruction::Borrow => unimplemented!(),

--- a/zkvm/tests/zkvm.rs
+++ b/zkvm/tests/zkvm.rs
@@ -43,8 +43,8 @@ impl ProgramHelper for Program {
     }
 
     fn input_helper(&mut self, qty: u64, flv: Scalar, pred: Predicate) -> &mut Self {
-        let prev_output = Output {
-            payload: vec![FrozenItem::Value(FrozenValue {
+        let prev_output = Contract {
+            payload: vec![PortableItem::Value(Value {
                 qty: Commitment::blinded(qty),
                 flv: Commitment::blinded(flv),
             })],
@@ -104,7 +104,7 @@ fn issuance_helper() -> (Scalar, Predicate, Scalar) {
 }
 
 fn test_helper(program: Vec<Instruction>, keys: &Vec<Scalar>) -> Result<TxID, VMError> {
-    let (tx, txid, txlog) = {
+    let (tx, _txid, _txlog) = {
         // Build tx
         let bp_gens = BulletproofGens::new(256, 1);
         let header = TxHeader {


### PR DESCRIPTION
Per #177, cleans up all infrastructure for reblinding of commitments. 

* `Value` has raw commitments, not `Variable`s. 
* `Output` is removed in favor of `Contract`.
* `FrozenItem` is removed in favor of `PortableItem`.
* `FrozenValue` is removed in favor of `Value`.
* `freeze`/`unfreeze` methods removed from Contract/Output.
* "attachment" terminology is removed, instead we "commit zkvm variables to R1CS" when we need R1CS variables.
* `VariableCommitment` type and array of such items is removed from VM state.
* `Variable` type is now a pair of commitments (can be made portable later if needed).
* `unblind` instruction is left unchanged.