### PR TITLE
zkvm: introduce anchors

### DIFF
--- a/check-markdown-links.rb
+++ b/check-markdown-links.rb
@@ -2,7 +2,11 @@
 require 'open-uri'
 require 'pathname'
 require 'pp'
-DO_NOT_CHECK_HTTP_LINKS = !!ENV["DO_NOT_CHECK_HTTP_LINKS"]
+DO_NOT_CHECK_HTTP_LINKS = !(ENV["DO_NOT_CHECK_HTTP_LINKS"].to_s =~ /^(|0|no|false)$/)
+
+if !DO_NOT_CHECK_HTTP_LINKS
+  puts "Checking remote URLs for 404 errors (set DO_NOT_CHECK_HTTP_LINKS to disable)"
+end
 
 # 1. Get all links
 # 2. For each link, check if it's good:

--- a/token/src/token.rs
+++ b/token/src/token.rs
@@ -86,9 +86,11 @@ mod tests {
                 b"USD".to_vec(),
             );
             let dest = Predicate::Key(VerificationKey::from_secret(&dest_key));
+            let dummy_block_id = Data::Opaque([0xffu8; 32].to_vec());
             let program = Program::build(|p| {
                 usd.issue_to(p, 10u64, dest.clone())
                     .push(Predicate::Key(VerificationKey::from_secret(&nonce_key)))
+                    .push(dummy_block_id)
                     .nonce()
                     .sign_tx()
             });
@@ -112,9 +114,11 @@ mod tests {
                 b"USD".to_vec(),
             );
             let dest = Predicate::Key(VerificationKey::from_secret(&dest_key));
+            let dummy_block_id = Data::Opaque([0xffu8; 32].to_vec());
             let issue_program = Program::build(|p| {
                 usd.issue_to(p, 10u64, dest.clone())
                     .push(Predicate::Key(VerificationKey::from_secret(&nonce_key)))
+                    .push(dummy_block_id)
                     .nonce()
                     .sign_tx()
             });

--- a/token/src/token.rs
+++ b/token/src/token.rs
@@ -1,5 +1,5 @@
 use curve25519_dalek::scalar::Scalar;
-use zkvm::{Commitment, Contract, Data, Input, Predicate, Program, TxID, Value};
+use zkvm::{Commitment, Data, Output, Predicate, Program, Value};
 
 /// Represents a ZkVM Token with unique flavor and embedded
 /// metadata protected by a user-supplied Predicate.
@@ -53,16 +53,8 @@ impl Token {
 
     /// Adds instructions to a program to retire a given UTXO.
     /// TBD: accept a qty/Token pairing to retire.
-    pub fn retire<'a>(
-        program: &'a mut Program,
-        prev_output: Contract,
-        txid: TxID,
-    ) -> &'a mut Program {
-        program
-            .push(Input::new(prev_output, txid))
-            .input()
-            .sign_tx()
-            .retire()
+    pub fn retire<'a>(program: &'a mut Program, prev_output: Output) -> &'a mut Program {
+        program.push(prev_output).input().sign_tx().retire()
     }
 }
 
@@ -75,6 +67,14 @@ mod tests {
         VerificationKey, Verifier,
     };
 
+    fn add_nonce(p: &mut Program, nonce_key: &Scalar) {
+        let dummy_block_id = Data::Opaque([0xffu8; 32].to_vec());
+        p.push(Predicate::Key(VerificationKey::from_secret(nonce_key)))
+            .push(dummy_block_id)
+            .nonce()
+            .sign_tx();
+    }
+
     #[test]
     fn issue_to() {
         let (tx, _, _) = {
@@ -86,13 +86,10 @@ mod tests {
                 b"USD".to_vec(),
             );
             let dest = Predicate::Key(VerificationKey::from_secret(&dest_key));
-            let dummy_block_id = Data::Opaque([0xffu8; 32].to_vec());
+
             let program = Program::build(|p| {
+                add_nonce(p, &nonce_key);
                 usd.issue_to(p, 10u64, dest.clone())
-                    .push(Predicate::Key(VerificationKey::from_secret(&nonce_key)))
-                    .push(dummy_block_id)
-                    .nonce()
-                    .sign_tx()
             });
             build(program, vec![issue_key, nonce_key]).unwrap()
         };
@@ -114,23 +111,18 @@ mod tests {
                 b"USD".to_vec(),
             );
             let dest = Predicate::Key(VerificationKey::from_secret(&dest_key));
-            let dummy_block_id = Data::Opaque([0xffu8; 32].to_vec());
             let issue_program = Program::build(|p| {
+                add_nonce(p, &nonce_key);
                 usd.issue_to(p, 10u64, dest.clone())
-                    .push(Predicate::Key(VerificationKey::from_secret(&nonce_key)))
-                    .push(dummy_block_id)
-                    .nonce()
-                    .sign_tx()
             });
-            let (_, issue_txid, issue_txlog) =
-                build(issue_program, vec![issue_key, nonce_key]).unwrap();
+            let (_, _, issue_txlog) = build(issue_program, vec![issue_key, nonce_key]).unwrap();
 
             let mut retire_program = Program::new();
-            let issue_output = match &issue_txlog[2] {
+            let issue_output = match &issue_txlog[3] {
                 Entry::Output(x) => x.clone(),
                 _ => return assert!(false, "TxLog entry doesn't match: expected Output"),
             };
-            Token::retire(&mut retire_program, issue_output, issue_txid);
+            Token::retire(&mut retire_program, issue_output);
             build(retire_program, vec![dest_key]).unwrap()
         };
 

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -1479,7 +1479,7 @@ _pred blockid_ **nonce** → _contract_
     T.commit("blockid", blockid)
     T.commit("predicate", pred)
     T.commit("maxtime", LE64(tx.maxtime))
-    nonce_anchor = T.challenge_bytes()
+    nonce_anchor = T.challenge_bytes("anchor")
     ```
 4. Pushes a new [contract](#contract-type) with:
     * an empty [payload](#contract-payload)
@@ -1504,7 +1504,7 @@ Blockchain state machine performs the following checks:
 1. The `blockid` is checked against the IDs of “recent” blocks when the transaction is applied to the blockchain. It must match a recent block, or the initial block of the blockchain.
 2. The `nonce_anchor` is checked for uniqueness against “recent” nonce anchors.
 
-To perform these checks, validators must keep a set of recent nonces and a set of recent block headers available. For scalability and to reduce resource demands on the network, these sets must be limited in size. So block signers can and should impose reasonable limits on the value of exp (which is the time by which the transaction must be included in a block or become invalid).
+To perform these checks, validators must keep a set of recent nonces and a set of recent block headers available. For scalability and to reduce resource demands on the network, these sets must be limited in size. So verifiers can and should impose reasonable limits on the value of exp (which is the time by which the transaction must be included in a block or become invalid).
 
 To support long-living pre-signed transactions, the protocol allows a nonce to use the blockchain’s initial block ID regardless of the `refscount` limit specified in the block headers.
 

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -407,7 +407,7 @@ Anchors can be created by the [`nonce`](#nonce) instruction or generated from pr
 VM keeps track of the last used anchor and fails if:
 
 1. by the end of the execution, no anchor was used (which means that [transaction ID](#transaction-id) is not unique), or
-2. an [`output`](#output) or [`contract`](#output) are invoked before the anchor is set (since they can’t be made unique).
+2. an [`output`](#output) or [`contract`](#contract) is invoked before the anchor is set (since they can’t be made unique).
 
 Note: using a chain of anchors enables the signer to have a predictable anchor computation, when the signable contract is created transiently from a just-opened UTXO, without the need to know about the entire transaction.
 

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -1277,20 +1277,25 @@ _qty flv metadata pred_ **issue** → _contract_
     T.commit("metadata", metadata)
     flavor = T.challenge_scalar("flavor")
     ```
-6. Checks that the `flv` has unblinded commitment to `flavor` by [deferring the point operation](#deferred-point-operations):
+6. Checks that the `flv` has unblinded commitment to `flavor`
+   by [deferring the point operation](#deferred-point-operations):
     ```
     flv == flavor·B
     ```
-7. Adds a 64-bit range proof for the `qty` to the [constraint system](#constraint-system) (see [Cloak protocol](../../spacesuit/spec.md) for the range proof definition).
+7. Adds a 64-bit range proof for the `qty` to the [constraint system](#constraint-system)
+   (see [Cloak protocol](../../spacesuit/spec.md) for the range proof definition).
 8. Adds an [issue entry](#issue-entry) to the [transaction log](#transaction-log).
-9. Creates a [contract](#contract-type) with the value as the only [payload](#contract-payload), protected by the predicate `pred`.
+9. Creates a [contract](#contract-type) with the value as the only [payload](#contract-payload),
+   protected by the predicate `pred`, consuming [VM’s last anchor](#vm-state)
+   and replacing it with this contract’s [ID](#contract-id).
 
 The value is now issued into the contract that must be unlocked
 using one of the contract instructions: [`signtx`](#signtx), [`delegate`](#delegate) or [`call`](#call).
 
 Fails if:
 * `pred` is not a valid [point](#point),
-* `flv` or `qty` are not [variable types](#variable-type).
+* `flv` or `qty` are not [variable types](#variable-type),
+* VM’s [last anchor](#vm-state) is missing.
 
 
 #### borrow
@@ -1424,10 +1429,8 @@ _prevoutput_ **input** → _contract_
 
 1. Pops a [data](#data-type) `prevoutput` representing the [unspent output structure](#output-structure) from the stack.
 2. Constructs a [contract](#contract-type) based on the `prevoutput` data and pushes it to the stack.
-3. For each decoded [value](#value-type), quantity variable is allocated first, flavor second.
-4. Adds [input entry](#input-entry) to the [transaction log](#transaction-log).
-5. Sets the [VM’s last anchor](#vm-state) to the [contract ID](#contract-id) of the claimed 
-[UTXO](#utxo).
+3. Adds [input entry](#input-entry) to the [transaction log](#transaction-log).
+4. Sets the [VM’s last anchor](#vm-state) to the [contract ID](#contract-id) of the claimed [UTXO](#utxo).
 
 Fails if the `prevoutput` is not a [data type](#data-type) with exact encoding of an [output structure](#output-structure).
 
@@ -1441,11 +1444,11 @@ _items... predicate_ **output:_k_** → ø
     ```
     T = Transcript("ZkVM.ratchet-anchor")
     T.commit("anchor", vm.last_anchor)
-    next_anchor = T.challenge_bytes("vm_anchor")
-    contract_anchor = T.challenge_bytes("contract_anchor")
+    next_anchor = T.challenge_bytes("anchor1")
+    contract_anchor = T.challenge_bytes("anchor2")
     ```
 4. Updates the [VM’s last anchor](#vm-state) with a ratcheted `next_anchor`:
-5. Uses ratcheted `contract_anchor` in the [output structure](#output-structure).
+5. Uses `contract_anchor` in the [output structure](#output-structure).
 6. Adds an [output entry](#output-entry) to the [transaction log](#transaction-log).
 
 Immediate data `k` is encoded as [LE32](#le32).

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -858,7 +858,7 @@ The VM is initialized with the following state:
 
 1. [Transaction](#transaction) as provided by the user.
 2. Extension flag set to `true` or `false` according to the [transaction versioning](#versioning) rules for the transaction version.
-3. Last anchor is set to `None`.
+3. Last anchor is set to ∅.
 4. Data stack is empty.
 5. Program stack is empty.
 6. Current program set to the transaction program; with zero offset.

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -378,11 +378,20 @@ Time bounds are available in the transaction as [expressions](#expression-type) 
 
 _Contract ID_ is a 32-byte commitment to the [contract](#contract-type) ([anchor](#anchor), [payload](#contract-payload) and [predicate](#predicate)) that is also a unique identifier.
 
+Contract ID is a hash of the contract’s [output structure](#output-structure):
+
+```
+T = Transcript("ZkVM.contractid")
+T.commit("contract", output_structure)
+id = T.challenge_bytes()
+```
+
 Contract ID makes [`delegate`](#delegate) signatures safe against [predicate](#predicate) key reuse:
 signature covers the unique contract ID, therefore preventing its replay against another contract,
 even if containing the same [payload](#contract-payload) and predicate.
 
 Contract ID is made globally unique due to use of [anchor](#anchor).
+
 
 ### Anchor
 

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -400,14 +400,13 @@ _Anchor_ is a 32-byte unique string that provides uniqueness to the [contract ID
 Anchors can be created by the [`nonce`](#nonce) instruction or generated from previously used unique contract IDs, tracked by the VM via [last anchor](#vm-state):
 
 1. Nonce contract has its anchor computed from the nonce parameters (see [`nonce`](#nonce) instruction).
-2. Claimed UTXO ([`input`](#input)) sets the VM’s [last anchor](#vm-state) to its [contract ID](#contract-id).
-3. Transient contract ([`contract`](#contract)) consumes the VM’s [last anchor](#vm-state) and replaces it with its [contract ID](#contract-id).
-4. Newly created outputs ([`output`](#output)) consume the VM’s [last anchor](#vm-state) and replace it with a ratcheted one (because the contract ID will be used as an anchor in a later transaction, via [`input`](#input)).
+2. Claimed UTXO ([`input`](#input)) sets the VM’s [last anchor](#vm-state) to its _ratcheted_ [contract ID](#contract-id) (see [`input`](#input)).
+3. Newly created contracts and outputs ([`contract`](#contract), [`output`](#contract)) consume the VM’s [last anchor](#vm-state) and replace it with its [contract ID](#contract-id).
 
 VM keeps track of the last used anchor and fails if:
 
 1. by the end of the execution, no anchor was used (which means that [transaction ID](#transaction-id) is not unique), or
-2. an [`output`](#output) or [`contract`](#contract) is invoked before the anchor is set (since they can’t be made unique).
+2. an [`issue`](#issue), [`output`](#output) or [`contract`](#contract) is invoked before the anchor is set (since they can’t be made unique).
 
 #### Note 1
 
@@ -417,11 +416,7 @@ from the contents of A, without the knowledge of the entire transaction.
 
 #### Note 2
 
-Transient contract sets its ID as an anchor because this can be done only once: the contract is soon destroyed by [`signtx`](#signtx), [`call`](#call) or [`delegate`](#delegate).
-
-This is not the case with [`output`](#output): if the output’s ID was set as an anchor, it'd be available in _two transactions_:
-in the current one (for the rest of its execution), but also in the _future transaction_,
-when the output is claimed by [`input`](#input) which sets the same contract ID as an anchor.
+Inputs _ratchet_ the contract ID because this contract ID was already available as an anchor in the _previous transaction_ (where the output was created).
 
 
 ### Transcript

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -1430,9 +1430,15 @@ _prevoutput_ **input** → _contract_
 1. Pops a [data](#data-type) `prevoutput` representing the [unspent output structure](#output-structure) from the stack.
 2. Constructs a [contract](#contract-type) based on the `prevoutput` data and pushes it to the stack.
 3. Adds [input entry](#input-entry) to the [transaction log](#transaction-log).
-4. Sets the [VM’s last anchor](#vm-state) to the [contract ID](#contract-id) of the claimed [UTXO](#utxo).
+4. Sets the [VM’s last anchor](#vm-state) to the ratcheted [contract ID](#contract-id):
+    ```
+    T = Transcript("ZkVM.ratchet-anchor")
+    T.commit("old", contract_id)
+    new_anchor = T.challenge_bytes("new")
+    ```
 
 Fails if the `prevoutput` is not a [data type](#data-type) with exact encoding of an [output structure](#output-structure).
+
 
 #### output
 
@@ -1440,16 +1446,9 @@ _items... predicate_ **output:_k_** → ø
 
 1. Pops [`predicate`](#predicate) from the stack.
 2. Pops `k` items from the stack.
-3. Ratchets the [VM’s last anchor](#vm-state):
-    ```
-    T = Transcript("ZkVM.ratchet-anchor")
-    T.commit("anchor", vm.last_anchor)
-    next_anchor = T.challenge_bytes("anchor1")
-    contract_anchor = T.challenge_bytes("anchor2")
-    ```
-4. Updates the [VM’s last anchor](#vm-state) with a ratcheted `next_anchor`:
-5. Uses `contract_anchor` in the [output structure](#output-structure).
-6. Adds an [output entry](#output-entry) to the [transaction log](#transaction-log).
+3. Creates a contract with the `k` items as a payload, the predicate `pred`, and anchor set to the [VM’s last anchor](#vm-state).
+4. Adds an [output entry](#output-entry) to the [transaction log](#transaction-log).
+5. Update the [VM’s last anchor](#vm-state) with the [contract ID](#contract-id) of the new contract.
 
 Immediate data `k` is encoded as [LE32](#le32).
 

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -383,7 +383,7 @@ Contract ID is a hash of the contract’s [output structure](#output-structure):
 ```
 T = Transcript("ZkVM.contractid")
 T.commit("contract", output_structure)
-id = T.challenge_bytes()
+id = T.challenge_bytes("id")
 ```
 
 Contract ID makes [`delegate`](#delegate) signatures safe against [predicate](#predicate) key reuse:

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -841,7 +841,7 @@ The ZkVM state consists of the static attributes and the state machine attribute
     * `tx_signature`
     * `cs_proof`
 2. Extension flag (boolean)
-3. Last [anchor](#anchor) or ∅ if unset.
+3. Last [anchor](#anchor) or ∅ if unset
 4. Data stack (array of [items](#types))
 5. Program stack (array of [programs](#program) with their offsets)
 6. Current [program](#program) with its offset
@@ -882,7 +882,7 @@ Then, the VM executes the current program till completion:
 
 If the execution finishes successfully, VM performs the finishing tasks:
 1. Checks if the stack is empty; fails otherwise.
-2. Checks if the last anchor is present; fails otherwise.
+2. Checks if the [last anchor](#vm-state) is set; fails otherwise.
 3. Computes [transaction ID](#transaction-id).
 4. Computes a verification statement for [transaction signature](#transaction-signature).
 5. Computes a verification statement for [constraint system proof](#constraint-system-proof).

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -1439,7 +1439,7 @@ _items... predicate_ **output:_k_** → ø
 
 Immediate data `k` is encoded as [LE32](#le32).
 
-Fails if VM’s [last anchor](#vm-state) is missing.
+Fails if VM’s [last anchor](#vm-state) is not set.
 
 
 #### contract

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -393,7 +393,7 @@ Uniqueness is provided via the [anchor](#anchor).
 ### Anchor
 
 _Anchor_ is a 32-byte unique string that provides uniqueness to the [contract ID](#contract-id).
-Anchors can be created by the [`nonce`](#nonce) instruction or generated from previously used unique contract IDs, tracked by the VM via [last anchor](#vm-state):
+Anchors can be created by the [`nonce`](#nonce) instruction or generated from unique contract IDs used earlier in the same transaction. These are tracked by the VM via [last anchor](#vm-state):
 
 1. Nonce contract has its anchor computed from the nonce parameters (see [`nonce`](#nonce) instruction).
 2. Claimed UTXO ([`input`](#input)) sets the VM’s [last anchor](#vm-state) to its _ratcheted_ [contract ID](#contract-id) (see [`input`](#input)).

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -1457,15 +1457,12 @@ A nonce serves two purposes:
 
 Blockchain state machine performs the following checks:
 
-1. The `blockid` is checked against the IDs of “recent” blocks when the transaction is applied to the blockchain. It must match a recent block, or the initial block of the blockchain, or be a string of 32 zero-bytes.
+1. The `blockid` is checked against the IDs of “recent” blocks when the transaction is applied to the blockchain. It must match a recent block, or the initial block of the blockchain.
 2. The nonce anchor is checked for uniqueness against “recent” nonces.
 
 To perform these checks, validators must keep a set of recent nonces and a set of recent block headers available. For scalability and to reduce resource demands on the network, these sets must be limited in size. So block signers can and should impose reasonable limits on the value of exp (which is the time by which the transaction must be included in a block or become invalid).
 
-Special cases:
-
-1. To support long-living pre-signed transactions, the protocol allows a nonce to use the blockchain’s initial block ID regardless of the `refscount` limit specified in the block headers.
-2. `blockid` is allowed to be all-zero string. This makes the nonce replayable on another chain, but still unique within any one chain.
+To support long-living pre-signed transactions, the protocol allows a nonce to use the blockchain’s initial block ID regardless of the `refscount` limit specified in the block headers.
 
 
 #### log

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -1435,7 +1435,7 @@ _items... predicate_ **output:_k_** → ø
 2. Pops `k` items from the stack.
 3. Creates a contract with the `k` items as a payload, the predicate `pred`, and anchor set to the [VM’s last anchor](#vm-state).
 4. Adds an [output entry](#output-entry) to the [transaction log](#transaction-log).
-5. Update the [VM’s last anchor](#vm-state) with the [contract ID](#contract-id) of the new contract.
+5. Updates the [VM’s last anchor](#vm-state) with the [contract ID](#contract-id) of the new contract.
 
 Immediate data `k` is encoded as [LE32](#le32).
 

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -1282,7 +1282,7 @@ using one of the contract instructions: [`signtx`](#signtx), [`delegate`](#deleg
 Fails if:
 * `pred` is not a valid [point](#point),
 * `flv` or `qty` are not [variable types](#variable-type),
-* VM’s [last anchor](#vm-state) is missing.
+* VM’s [last anchor](#vm-state) is not set.
 
 
 #### borrow

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -527,8 +527,7 @@ but in the [output](#output-structure) only the [portable types](#portable-types
 
 ### Output structure
 
-Output represents a _snapshot_ of a [contract](#contract-type)
-and can only contain [portable types](#portable-types).
+Output is a serialized [contract](#contract-type):
 
 ```
       Output  =  Anchor || Predicate  ||  LE32(k)  ||  Item[0]  || ... ||  Item[k-1]
@@ -542,7 +541,7 @@ and can only contain [portable types](#portable-types).
 ### UTXO
 
 UTXO stands for Unspent Transaction [Output](#output-structure).
-UTXO is uniquely identified by the [ID](#contract-id) of the contract in the output.
+UTXO is uniquely identified by the [ID](#contract-id) of the contract represented by the output.
 
 ### Constraint system
 

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -843,7 +843,7 @@ The ZkVM state consists of the static attributes and the state machine attribute
     * `tx_signature`
     * `cs_proof`
 2. Extension flag (boolean)
-3. Last anchor (optional [anchor](#anchor): `None` or `Some(anchor)`)
+3. Last [anchor](#anchor) or ∅ if unset.
 4. Data stack (array of [items](#types))
 5. Program stack (array of [programs](#program) with their offsets)
 6. Current [program](#program) with its offset

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -384,7 +384,7 @@ T.commit("contract", output_structure)
 id = T.challenge_bytes("id")
 ```
 
-Contract ID makes signatures safe against reused [predicate](#predicate) keys:
+Contract ID makes signatures safe against reused [verification keys](#verification-key) in [predicates](#predicate):
 a signature covers the unique contract ID, therefore preventing its replay against another contract,
 even if containing the same [payload](#contract-payload) and predicate.
 

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -542,7 +542,7 @@ and can only contain [portable types](#portable-types).
 ### UTXO
 
 UTXO stands for Unspent Transaction [Output](#output-structure).
-UTXO is uniquely identified by the [contract ID](#contract-id).
+UTXO is uniquely identified by the [ID](#contract-id) of the contract in the output.
 
 
 ### Constraint system

--- a/zkvm/src/contract.rs
+++ b/zkvm/src/contract.rs
@@ -126,11 +126,10 @@ impl ContractID {
         t.challenge_bytes(b"id", &mut id);
         Self(id)
     }
-}
 
-impl From<ContractID> for Anchor {
-    fn from(c: ContractID) -> Self {
-        Anchor(c.0)
+    /// Re-wraps contract ID bytes into Anchor
+    pub(crate) fn to_anchor(self) -> Anchor {
+        Anchor(self.0)
     }
 }
 

--- a/zkvm/src/contract.rs
+++ b/zkvm/src/contract.rs
@@ -212,13 +212,10 @@ impl Contract {
             if k > r.len() {
                 return Err(VMError::FormatError);
             }
-
             let mut payload: Vec<PortableItem> = Vec::with_capacity(k);
             for _ in 0..k {
-                let item = PortableItem::decode(r)?;
-                payload.push(item);
+                payload.push(PortableItem::decode(r)?);
             }
-
             Ok(Contract {
                 anchor,
                 predicate,

--- a/zkvm/src/contract.rs
+++ b/zkvm/src/contract.rs
@@ -1,9 +1,10 @@
+use merlin::Transcript;
+
 use crate::constraints::Commitment;
 use crate::encoding;
 use crate::encoding::SliceReader;
 use crate::errors::VMError;
 use crate::predicate::Predicate;
-use crate::txlog::{TxID, UTXO};
 use crate::types::{Data, Value};
 
 /// Prefix for the data type in the Output Structure
@@ -12,9 +13,20 @@ pub const DATA_TYPE: u8 = 0x00;
 /// Prefix for the value type in the Output Structure
 pub const VALUE_TYPE: u8 = 0x01;
 
+/// A unique identifier for an anchor
+#[derive(Copy,Clone,Debug)]
+pub struct Anchor([u8; 32]);
+
+/// A unique identifier for a contract.
+#[derive(Copy,Clone,Debug)]
+pub struct ContractID([u8; 32]);
+
 /// A ZkVM contract that holds a _payload_ (a list of portable items) protected by a _predicate_.
 #[derive(Clone, Debug)]
 pub struct Contract {
+    /// Anchor string which makes the contract unique.
+    pub anchor: Anchor,
+
     /// List of payload items.
     pub payload: Vec<PortableItem>,
 
@@ -32,58 +44,89 @@ pub enum PortableItem {
     Value(Value),
 }
 
-/// Representation of a claimed UTXO for the `input` instruction.
+/// Representation of the claimed UTXO
 #[derive(Clone, Debug)]
 pub struct Input {
-    prev_output: Contract,
-    utxo: UTXO,
-    txid: TxID,
+    contract: Contract,
+    id: ContractID,
 }
 
 impl Input {
-    /// Creates an Input with a given Output and transaction id
-    pub fn new(prev_output: Contract, txid: TxID) -> Self {
-        let utxo = UTXO::from_output(&prev_output.to_bytes(), &txid);
-        Input {
-            prev_output,
-            utxo,
-            txid,
+    /// Creates an Input with a given contract
+    pub fn new(contract: Contract) -> Self {
+        Self {
+            id: contract.id(),
+            contract,
         }
     }
 
     /// Parses an input from a byte array.
     pub fn from_bytes(data: Vec<u8>) -> Result<Self, VMError> {
-        let output = SliceReader::parse(&data, |r| Self::decode(r))?;
-        Ok(output)
+        let (contract, id) = SliceReader::parse(&data, |r| Contract::decode(r))?;
+        Ok(Self{ contract, id })
     }
 
-    /// Precise serialized length in bytes for the Input
+    /// Precise length of a serialized contract
     pub fn serialized_length(&self) -> usize {
-        32 + self.prev_output.serialized_length()
+        self.contract.serialized_length()
     }
 
     /// Serializes the input to a byte array.
     pub fn encode(&self, buf: &mut Vec<u8>) {
-        encoding::write_bytes(&self.txid.0, buf);
-        self.prev_output.encode(buf);
+        self.contract.encode(buf);
     }
 
-    /// Unfreezes the input by converting it to the Contract an UTXO ID.
-    pub(crate) fn unfreeze(self) -> (Contract, UTXO) {
-        (self.prev_output, self.utxo)
+    pub(crate) fn unfreeze(self) -> (Contract, ContractID) {
+        (self.contract, self.id)
+    }
+}
+
+impl Anchor {
+    /// Provides a view into the anchor’s bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
     }
 
-    fn decode<'a>(reader: &mut SliceReader<'a>) -> Result<Self, VMError> {
-        // Input  =  PreviousTxID || PreviousOutput
-        // PreviousTxID  =  <32 bytes>
-        let txid = TxID(reader.read_u8x32()?);
-        let (prev_output, contract_bytes) = reader.slice(|r| Contract::decode(r))?;
-        let utxo = UTXO::from_output(contract_bytes, &txid);
-        Ok(Input {
-            prev_output,
-            utxo,
-            txid,
-        })
+    /// Computes a nonce anchor from its components
+    pub fn nonce(blockid: [u8;32], predicate: &Predicate, maxtime: u64) -> Self {
+        let mut t = Transcript::new(b"ZkVM.nonce");
+        t.commit_bytes(b"blockid", &blockid);
+        t.commit_bytes(b"predicate", predicate.to_point().as_bytes());
+        t.commit_u64(b"maxtime", maxtime);
+        let mut nonce = [0u8; 32];
+        t.challenge_bytes(b"anchor", &mut nonce);
+        Self(nonce)
+    }
+
+    /// Ratchet the anchor into two new anchors
+    pub fn ratchet(&self) -> (Self, Self) {
+        let mut t = Transcript::new(b"ZkVM.ratchet-anchor");
+        t.commit_bytes(b"anchor", &self.0);
+        let mut a1 = [0u8; 32];
+        let mut a2 = [0u8; 32];
+        t.challenge_bytes(b"anchor1", &mut a1);
+        t.challenge_bytes(b"anchor1", &mut a2);
+        (Self(a1), Self(a2))
+    }
+}
+
+impl ContractID {
+    /// Provides a view into the contract ID's bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// Converts the contract ID to an anchor.
+    pub fn to_anchor(self) -> Anchor {
+        Anchor(self.0)
+    }
+
+    fn from_serialized_contract(bytes: &[u8]) -> Self {
+        let mut t = Transcript::new(b"ZkVM.contractid");
+        t.commit_bytes(b"contract", bytes);
+        let mut id = [0u8; 32];
+        t.challenge_bytes(b"id", &mut id);
+        Self(id)
     }
 }
 
@@ -132,11 +175,17 @@ impl PortableItem {
 }
 
 impl Contract {
+
     /// Converts self to vector of bytes
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut buf = Vec::with_capacity(self.serialized_length());
         self.encode(&mut buf);
         buf
+    }
+
+    /// Serializes the contract and computes its ID.
+    pub fn id(&self) -> ContractID {
+        ContractID::from_serialized_contract(&self.to_bytes())
     }
 
     /// Precise length of a serialized contract
@@ -149,37 +198,44 @@ impl Contract {
     }
 
     /// Serializes the contract to a byte array
-    fn encode(&self, buf: &mut Vec<u8>) {
+    pub fn encode(&self, buf: &mut Vec<u8>) {
+        encoding::write_bytes(&self.anchor.0, buf);
         encoding::write_point(&self.predicate.to_point(), buf);
         encoding::write_u32(self.payload.len() as u32, buf);
-
         for item in self.payload.iter() {
             item.encode(buf);
         }
     }
 
-    fn decode<'a>(output: &mut SliceReader<'a>) -> Result<Self, VMError> {
-        //    Output  =  Predicate  ||  LE32(k)  ||  Item[0]  || ... ||  Item[k-1]
+    fn decode<'a>(reader: &mut SliceReader<'a>) -> Result<(Self, ContractID), VMError> {
+        //    Output  =  Anchor  ||  Predicate  ||  LE32(k)  ||  Item[0]  || ... ||  Item[k-1]
+        //    Anchor  =  <32 bytes>
         // Predicate  =  <32 bytes>
         //      Item  =  enum { Data, Value }
         //      Data  =  0x00  ||  LE32(len)  ||  <bytes>
         //     Value  =  0x01  ||  <32 bytes> ||  <32 bytes>
+        let (contract, serialized_contract) = reader.slice(|r| {
+            let anchor = Anchor(r.read_u8x32()?);
+            let predicate = Predicate::Opaque(r.read_point()?);
+            let k = r.read_size()?;
 
-        let predicate = Predicate::Opaque(output.read_point()?);
-        let k = output.read_size()?;
+            // sanity check: avoid allocating unreasonably more memory
+            // just because an untrusted length prefix says so.
+            if k > r.len() {
+                return Err(VMError::FormatError);
+            }
 
-        // sanity check: avoid allocating unreasonably more memory
-        // just because an untrusted length prefix says so.
-        if k > output.len() {
-            return Err(VMError::FormatError);
-        }
+            let mut payload: Vec<PortableItem> = Vec::with_capacity(k);
+            for _ in 0..k {
+                let item = PortableItem::decode(r)?;
+                payload.push(item);
+            }
 
-        let mut payload: Vec<PortableItem> = Vec::with_capacity(k);
-        for _ in 0..k {
-            let item = PortableItem::decode(output)?;
-            payload.push(item);
-        }
+            Ok(Contract { anchor, predicate, payload })
+        })?;
 
-        Ok(Contract { predicate, payload })
+        let id = ContractID::from_serialized_contract(serialized_contract);
+
+        Ok((contract, id))
     }
 }

--- a/zkvm/src/contract.rs
+++ b/zkvm/src/contract.rs
@@ -189,7 +189,7 @@ impl Contract {
 
     /// Precise length of a serialized contract
     fn serialized_length(&self) -> usize {
-        let mut size = 32 + 4;
+        let mut size = 32 + 32 + 4;
         for item in self.payload.iter() {
             size += item.serialized_length();
         }

--- a/zkvm/src/contract.rs
+++ b/zkvm/src/contract.rs
@@ -52,7 +52,7 @@ pub struct Output {
 }
 
 impl Output {
-    /// Creates an Input with a given contract
+    /// Creates an Output with a given contract
     pub fn new(contract: Contract) -> Self {
         let mut buf = Vec::with_capacity(contract.serialized_length());
         contract.encode(&mut buf);

--- a/zkvm/src/contract.rs
+++ b/zkvm/src/contract.rs
@@ -14,11 +14,11 @@ pub const DATA_TYPE: u8 = 0x00;
 pub const VALUE_TYPE: u8 = 0x01;
 
 /// A unique identifier for an anchor
-#[derive(Copy,Clone,Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct Anchor([u8; 32]);
 
 /// A unique identifier for a contract.
-#[derive(Copy,Clone,Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct ContractID([u8; 32]);
 
 /// A ZkVM contract that holds a _payload_ (a list of portable items) protected by a _predicate_.
@@ -63,7 +63,7 @@ impl Input {
     /// Parses an input from a byte array.
     pub fn from_bytes(data: Vec<u8>) -> Result<Self, VMError> {
         let (contract, id) = SliceReader::parse(&data, |r| Contract::decode(r))?;
-        Ok(Self{ contract, id })
+        Ok(Self { contract, id })
     }
 
     /// Precise length of a serialized contract
@@ -88,7 +88,7 @@ impl Anchor {
     }
 
     /// Computes a nonce anchor from its components
-    pub fn nonce(blockid: [u8;32], predicate: &Predicate, maxtime: u64) -> Self {
+    pub fn nonce(blockid: [u8; 32], predicate: &Predicate, maxtime: u64) -> Self {
         let mut t = Transcript::new(b"ZkVM.nonce");
         t.commit_bytes(b"blockid", &blockid);
         t.commit_bytes(b"predicate", predicate.to_point().as_bytes());
@@ -175,7 +175,6 @@ impl PortableItem {
 }
 
 impl Contract {
-
     /// Converts self to vector of bytes
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut buf = Vec::with_capacity(self.serialized_length());
@@ -231,7 +230,11 @@ impl Contract {
                 payload.push(item);
             }
 
-            Ok(Contract { anchor, predicate, payload })
+            Ok(Contract {
+                anchor,
+                predicate,
+                payload,
+            })
         })?;
 
         let id = ContractID::from_serialized_contract(serialized_contract);

--- a/zkvm/src/contract.rs
+++ b/zkvm/src/contract.rs
@@ -66,13 +66,18 @@ impl Output {
         Ok(Self { contract, id })
     }
 
+    /// Returns the contract ID
+    pub fn id(&self) -> ContractID {
+        self.id
+    }
+
     /// Gives a reference to the contract
-    pub(crate) fn as_contract(&self) -> &Contract {
+    pub fn as_contract(&self) -> &Contract {
         &self.contract
     }
 
     /// Converts output to a contract and also returns its precomputed ID
-    pub(crate) fn into_contract(self) -> (Contract, ContractID) {
+    pub fn into_contract(self) -> (Contract, ContractID) {
         (self.contract, self.id)
     }
 }

--- a/zkvm/src/errors.rs
+++ b/zkvm/src/errors.rs
@@ -48,25 +48,25 @@ pub enum VMError {
     #[fail(display = "Item is not an expression.")]
     TypeNotExpression,
 
-    /// This error occurs when an instruction requires a predicate type.
+    /// This error occurs when an instruction requires a predicate data type.
     #[fail(display = "Item is not a predicate.")]
     TypeNotPredicate,
 
-    /// This error occurs when an instruction requires a commitment type.
+    /// This error occurs when an instruction requires a commitment data type.
     #[fail(display = "Item is not a commitment.")]
     TypeNotCommitment,
 
-    /// This error occurs when an instruction requires an input type.
-    #[fail(display = "Item is not an input.")]
-    TypeNotInput,
+    /// This error occurs when an instruction requires an output data type.
+    #[fail(display = "Item is not an output.")]
+    TypeNotOutput,
 
     /// This error occurs when an instruction requires a constraint type.
     #[fail(display = "Item is not a constraint.")]
     TypeNotConstraint,
 
-    /// This error occurs when an instruction requires a scalar witness type.
-    #[fail(display = "Item is not a Scalar Witness.")]
-    TypeNotScalarWitness,
+    /// This error occurs when an instruction requires a scalar data type.
+    #[fail(display = "Item is not a scalar.")]
+    TypeNotScalar,
 
     /// This error occurs when an instruction expects a key type.
     #[fail(display = "Item is not a key.")]

--- a/zkvm/src/errors.rs
+++ b/zkvm/src/errors.rs
@@ -100,9 +100,9 @@ pub enum VMError {
     #[fail(display = "Stack is not cleared by the program")]
     StackNotClean,
 
-    /// This error occurs when VM's uniqueness flag remains false.
-    #[fail(display = "Tx ID is not made unique via `input` or `nonce`")]
-    NotUniqueTxid,
+    /// This error occurs when VM's anchor remains unset.
+    #[fail(display = "VM anchor is not set via `input` or `nonce`")]
+    AnchorMissing,
 
     /// This error occurs when VM's deferred schnorr checks fail
     #[fail(display = "Deferred point operations failed")]

--- a/zkvm/src/lib.rs
+++ b/zkvm/src/lib.rs
@@ -22,7 +22,7 @@ mod verifier;
 mod vm;
 
 pub use self::constraints::{Commitment, Constraint, Expression, Variable};
-pub use self::contract::{Anchor, Contract, ContractID, Input, PortableItem};
+pub use self::contract::{Anchor, Contract, ContractID, Output, PortableItem};
 pub use self::errors::VMError;
 pub use self::merkle::{MerkleItem, MerkleNeighbor, MerkleTree};
 pub use self::ops::{Instruction, Opcode, Program};

--- a/zkvm/src/lib.rs
+++ b/zkvm/src/lib.rs
@@ -22,7 +22,7 @@ mod verifier;
 mod vm;
 
 pub use self::constraints::{Commitment, Constraint, Expression, Variable};
-pub use self::contract::{Contract, Input, Anchor, ContractID, PortableItem};
+pub use self::contract::{Anchor, Contract, ContractID, Input, PortableItem};
 pub use self::errors::VMError;
 pub use self::merkle::{MerkleItem, MerkleNeighbor, MerkleTree};
 pub use self::ops::{Instruction, Opcode, Program};

--- a/zkvm/src/lib.rs
+++ b/zkvm/src/lib.rs
@@ -22,7 +22,7 @@ mod verifier;
 mod vm;
 
 pub use self::constraints::{Commitment, Constraint, Expression, Variable};
-pub use self::contract::{Contract, Input, PortableItem};
+pub use self::contract::{Contract, Input, Anchor, ContractID, PortableItem};
 pub use self::errors::VMError;
 pub use self::merkle::{MerkleItem, MerkleNeighbor, MerkleTree};
 pub use self::ops::{Instruction, Opcode, Program};

--- a/zkvm/src/txlog.rs
+++ b/zkvm/src/txlog.rs
@@ -1,8 +1,8 @@
 use curve25519_dalek::ristretto::CompressedRistretto;
 use merlin::Transcript;
 
-use crate::contract::Contract;
-use crate::merkle::{MerkleItem, MerkleTree};
+use crate::contract::{Anchor,ContractID};
+use crate::errors::VMError;
 use crate::transcript::TranscriptProtocol;
 use crate::vm::TxHeader;
 
@@ -16,9 +16,9 @@ pub enum Entry {
     Header(TxHeader),
     Issue(CompressedRistretto, CompressedRistretto),
     Retire(CompressedRistretto, CompressedRistretto),
-    Input(UTXO),
-    Nonce(CompressedRistretto, u64),
-    Output(Contract),
+    Input(ContractID),
+    Output(ContractID),
+    Nonce([u8;32], u64, Anchor),
     Data(Vec<u8>),
     Import, // TBD: parameters
     Export, // TBD: parameters
@@ -67,15 +67,16 @@ impl MerkleItem for Entry {
                 t.commit_point(b"retire.q", q);
                 t.commit_point(b"retire.f", f);
             }
-            Entry::Input(utxo) => {
-                t.commit_bytes(b"input", &utxo.0);
+            Entry::Input(id) => {
+                t.commit_bytes(b"input", id.as_bytes());
             }
-            Entry::Nonce(pred, maxtime) => {
-                t.commit_point(b"nonce.p", &pred);
+            Entry::Output(id) => {
+                t.commit_bytes(b"output", id.as_bytes());
+            }
+            Entry::Nonce(blockid, maxtime, anchor) => {
+                t.commit_bytes(b"nonce.b", blockid);
                 t.commit_u64(b"nonce.t", *maxtime);
-            }
-            Entry::Output(contract) => {
-                t.commit_bytes(b"output", &contract.to_bytes());
+                t.commit_bytes(b"nonce.n", anchor.as_bytes());
             }
             Entry::Data(data) => {
                 t.commit_bytes(b"data", data);
@@ -107,9 +108,9 @@ mod tests {
                 CompressedRistretto::from_slice(&[0u8; 32]),
                 CompressedRistretto::from_slice(&[1u8; 32]),
             ),
-            Entry::Nonce(CompressedRistretto::from_slice(&[1u8; 32]), 0u64),
-            Entry::Nonce(CompressedRistretto::from_slice(&[2u8; 32]), 1u64),
-            Entry::Nonce(CompressedRistretto::from_slice(&[3u8; 32]), 2u64),
+            Entry::Data(vec![0u8]),
+            Entry::Data(vec![1u8]),
+            Entry::Data(vec![2u8]),
         ]
     }
 

--- a/zkvm/src/txlog.rs
+++ b/zkvm/src/txlog.rs
@@ -1,7 +1,7 @@
 use curve25519_dalek::ristretto::CompressedRistretto;
 use merlin::Transcript;
 
-use crate::contract::{Anchor, ContractID};
+use crate::contract::{Anchor, ContractID, Output};
 use crate::merkle::{MerkleItem, MerkleTree};
 use crate::transcript::TranscriptProtocol;
 use crate::vm::TxHeader;
@@ -17,7 +17,7 @@ pub enum Entry {
     Issue(CompressedRistretto, CompressedRistretto),
     Retire(CompressedRistretto, CompressedRistretto),
     Input(ContractID),
-    Output(ContractID),
+    Output(Output),
     Nonce([u8; 32], u64, Anchor),
     Data(Vec<u8>),
     Import, // TBD: parameters
@@ -70,8 +70,8 @@ impl MerkleItem for Entry {
             Entry::Input(id) => {
                 t.commit_bytes(b"input", id.as_bytes());
             }
-            Entry::Output(id) => {
-                t.commit_bytes(b"output", id.as_bytes());
+            Entry::Output(output) => {
+                t.commit_bytes(b"output", output.id().as_bytes());
             }
             Entry::Nonce(blockid, maxtime, anchor) => {
                 t.commit_bytes(b"nonce.b", blockid);

--- a/zkvm/src/txlog.rs
+++ b/zkvm/src/txlog.rs
@@ -1,8 +1,8 @@
 use curve25519_dalek::ristretto::CompressedRistretto;
 use merlin::Transcript;
 
-use crate::contract::{Anchor,ContractID};
-use crate::merkle::{MerkleItem,MerkleTree};
+use crate::contract::{Anchor, ContractID};
+use crate::merkle::{MerkleItem, MerkleTree};
 use crate::transcript::TranscriptProtocol;
 use crate::vm::TxHeader;
 
@@ -18,7 +18,7 @@ pub enum Entry {
     Retire(CompressedRistretto, CompressedRistretto),
     Input(ContractID),
     Output(ContractID),
-    Nonce([u8;32], u64, Anchor),
+    Nonce([u8; 32], u64, Anchor),
     Data(Vec<u8>),
     Import, // TBD: parameters
     Export, // TBD: parameters

--- a/zkvm/src/txlog.rs
+++ b/zkvm/src/txlog.rs
@@ -2,7 +2,7 @@ use curve25519_dalek::ristretto::CompressedRistretto;
 use merlin::Transcript;
 
 use crate::contract::{Anchor,ContractID};
-use crate::errors::VMError;
+use crate::merkle::{MerkleItem,MerkleTree};
 use crate::transcript::TranscriptProtocol;
 use crate::vm::TxHeader;
 

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -207,7 +207,7 @@ impl Data {
         }
     }
 
-    /// Downcast the data item to an `Input` type.
+    /// Downcast the data item to an `Output` type.
     pub fn to_output(self) -> Result<Output, VMError> {
         match self {
             Data::Opaque(data) => SliceReader::parse(&data, |r| Output::decode(r)),

--- a/zkvm/src/types.rs
+++ b/zkvm/src/types.rs
@@ -156,7 +156,7 @@ impl Data {
             Data::Predicate(predicate) => predicate.serialized_length(),
             Data::Commitment(commitment) => commitment.serialized_length(),
             Data::Scalar(scalar) => scalar.serialized_length(),
-            Data::Output(output) => output.as_contract().serialized_length(),
+            Data::Output(output) => output.serialized_length(),
         }
     }
 
@@ -236,7 +236,7 @@ impl Data {
             Data::Predicate(predicate) => predicate.encode(buf),
             Data::Commitment(commitment) => commitment.encode(buf),
             Data::Scalar(scalar) => scalar.encode(buf),
-            Data::Output(output) => output.as_contract().encode(buf),
+            Data::Output(output) => output.encode(buf),
         };
     }
 }

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -9,7 +9,7 @@ use std::iter::FromIterator;
 use std::mem;
 
 use crate::constraints::{Commitment, Constraint, Expression, Variable};
-use crate::contract::{Contract, PortableItem};
+use crate::contract::{Anchor, Contract, PortableItem};
 use crate::encoding::SliceReader;
 use crate::errors::VMError;
 use crate::ops::Instruction;
@@ -75,9 +75,8 @@ where
     // we allow treating unassigned opcodes as no-ops.
     extension: bool,
 
-    // set to true by `input` and `nonce` instructions
-    // when the txid is guaranteed to be unique.
-    unique: bool,
+    // updated by input/nonce/contract/output instructions
+    last_anchor: Option<Anchor>,
 
     // stack of all items in the VM
     stack: Vec<Item>,
@@ -131,7 +130,7 @@ where
             mintime: header.mintime,
             maxtime: header.maxtime,
             extension: header.version > CURRENT_VERSION,
-            unique: false,
+            last_anchor: None,
             delegate,
             stack: Vec::new(),
             current_run: run,
@@ -152,8 +151,8 @@ where
             return Err(VMError::StackNotClean);
         }
 
-        if self.unique == false {
-            return Err(VMError::NotUniqueTxid);
+        if self.last_anchor.is_none() {
+            return Err(VMError::AnchorMissing);
         }
 
         let txid = TxID::from_log(&self.txlog[..]);
@@ -386,16 +385,23 @@ where
         Ok(())
     }
 
+    // pred blockid `nonce` → contract
     fn nonce(&mut self) -> Result<(), VMError> {
+        let blockid = self.pop_item()?.to_data()?.to_bytes();
+        let blockid = SliceReader::parse(&blockid, |r| {
+            r.read_u8x32()
+        })?;
         let predicate = self.pop_item()?.to_data()?.to_predicate()?;
-        let point = predicate.to_point();
+        let nonce_anchor = Anchor::nonce(blockid, &predicate, self.maxtime);
+
         let contract = Contract {
+            anchor: nonce_anchor,
             predicate,
             payload: Vec::new(),
         };
-        self.txlog.push(Entry::Nonce(point, self.maxtime));
+        self.last_anchor = Some(contract.id().to_anchor());
+        self.txlog.push(Entry::Nonce(blockid, self.maxtime, nonce_anchor));
         self.push_item(contract);
-        self.unique = true;
         Ok(())
     }
 
@@ -435,10 +441,13 @@ where
 
         self.txlog.push(Entry::Issue(qty_point, flv_point));
 
+        let anchor = self.last_anchor.ok_or(VMError::AnchorMissing)?;
         let contract = Contract {
+            anchor,
             predicate,
             payload: vec![PortableItem::Value(value)],
         };
+        self.last_anchor = Some(contract.id().to_anchor());
 
         self.push_item(contract);
         Ok(())
@@ -501,27 +510,40 @@ where
     /// _input_ **input** → _contract_
     fn input(&mut self) -> Result<(), VMError> {
         let input = self.pop_item()?.to_data()?.to_input()?;
-        let (contract, utxo) = input.unfreeze();
+        let (contract, contract_id) = input.unfreeze();
         self.push_item(contract);
-        self.txlog.push(Entry::Input(utxo));
-        self.unique = true;
+        self.txlog.push(Entry::Input(contract_id));
+        self.last_anchor = Some(contract_id.to_anchor());
         Ok(())
     }
 
     /// _items... predicate_ **output:_k_** → ø
     fn output(&mut self, k: usize) -> Result<(), VMError> {
-        let contract = self.pop_contract(k)?;
-        self.txlog.push(Entry::Output(contract));
+        let (predicate, payload) = self.pop_contract(k)?;
+        let (next_anchor, contract_anchor) = self.last_anchor.ok_or(VMError::AnchorMissing)?.ratchet();
+        self.last_anchor = Some(next_anchor);
+        let contract = Contract {
+            anchor: contract_anchor,
+            payload,
+            predicate
+        };
+        self.txlog.push(Entry::Output(contract.id()));
         Ok(())
     }
 
     fn contract(&mut self, k: usize) -> Result<(), VMError> {
-        let contract = self.pop_contract(k)?;
+        let (predicate, payload) = self.pop_contract(k)?;
+        let contract = Contract {
+            anchor: self.last_anchor.ok_or(VMError::AnchorMissing)?,
+            payload,
+            predicate
+        };
+        self.last_anchor = Some(contract.id().to_anchor());
         self.push_item(contract);
         Ok(())
     }
 
-    fn pop_contract(&mut self, k: usize) -> Result<Contract, VMError> {
+    fn pop_contract(&mut self, k: usize) -> Result<(Predicate, Vec<PortableItem>), VMError> {
         let predicate = self.pop_item()?.to_data()?.to_predicate()?;
 
         if k > self.stack.len() {
@@ -534,7 +556,7 @@ where
             .map(|item| item.to_portable())
             .collect::<Result<Vec<_>, _>>()?;
 
-        Ok(Contract { predicate, payload })
+        Ok((predicate, payload))
     }
 
     fn cloak(&mut self, m: usize, n: usize) -> Result<(), VMError> {

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -75,7 +75,7 @@ where
     // we allow treating unassigned opcodes as no-ops.
     extension: bool,
 
-    // updated by input/nonce/contract/output instructions
+    // updated by nonce/input/issue/contract/output instructions
     last_anchor: Option<Anchor>,
 
     // stack of all items in the VM

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -506,7 +506,7 @@ where
         let (contract, contract_id) = output.into_contract();
         self.push_item(contract);
         self.txlog.push(Entry::Input(contract_id));
-        self.last_anchor = Some(Anchor::from(contract_id).ratchet());
+        self.last_anchor = Some(contract_id.to_anchor().ratchet());
         Ok(())
     }
 
@@ -796,7 +796,7 @@ where
             payload,
         };
         let output = Output::new(c);
-        self.last_anchor = Some(output.id().into());
+        self.last_anchor = Some(output.id().to_anchor());
         Ok(output)
     }
 }

--- a/zkvm/tests/zkvm.rs
+++ b/zkvm/tests/zkvm.rs
@@ -29,16 +29,19 @@ impl ProgramHelper for Program {
         issuance_pred: Predicate,
         nonce_pred: Predicate,
     ) -> &mut Self {
-        self.push(Commitment::blinded_with_factor(qty, Scalar::from(1u64))) // stack: qty
+        let dummy_block_id = Data::Opaque([0xffu8; 32].to_vec());
+        self.push(nonce_pred)
+            .push(dummy_block_id)
+            .nonce()
+            .sign_tx() // stack is clean
+            
+            .push(Commitment::blinded_with_factor(qty, Scalar::from(1u64))) // stack: qty
             .var() // stack: qty-var
             .push(Commitment::unblinded(flv)) // stack: qty-var, flv
             .var() // stack: qty-var, flv-var
             .push(Data::default()) // stack: qty-var, flv-var, data
             .push(issuance_pred) // stack: qty-var, flv-var, data, pred
             .issue() // stack: issue-contract
-            .push(nonce_pred) // stack: issue-contract, pred
-            .nonce() // stack: issue-contract, nonce-contract
-            .sign_tx() // stack: issue-contract
             .sign_tx(); // stack: issued-value
         self
     }
@@ -176,7 +179,7 @@ fn issue() {
         Ok(txid) => {
             // Check txid
             assert_eq!(
-                "5245c74137fec1e97159a45e737c4eb8e703fb0f1d151e842351e2ab834763be",
+                "ee88427053ca9ee7726a633e39334415139dc7931a88a104456805f82f07f9a3",
                 hex::encode(txid.0)
             );
         }

--- a/zkvm/tests/zkvm.rs
+++ b/zkvm/tests/zkvm.rs
@@ -1,5 +1,6 @@
 use bulletproofs::{BulletproofGens, PedersenGens};
 use curve25519_dalek::scalar::Scalar;
+use curve25519_dalek::constants::RISTRETTO_BASEPOINT_COMPRESSED;
 use hex;
 
 use zkvm::*;
@@ -43,14 +44,16 @@ impl ProgramHelper for Program {
     }
 
     fn input_helper(&mut self, qty: u64, flv: Scalar, pred: Predicate) -> &mut Self {
+        let anchor = Anchor::nonce([0u8;32], &Predicate::Opaque(RISTRETTO_BASEPOINT_COMPRESSED), 0);
         let prev_output = Contract {
+            anchor,
             payload: vec![PortableItem::Value(Value {
                 qty: Commitment::blinded(qty),
                 flv: Commitment::blinded(flv),
             })],
             predicate: pred,
         };
-        self.push(Input::new(prev_output, TxID([0; 32]))) // stack: input-data
+        self.push(Input::new(prev_output)) // stack: input-data
             .input() // stack: input-contract
             .sign_tx(); // stack: input-value
         self

--- a/zkvm/tests/zkvm.rs
+++ b/zkvm/tests/zkvm.rs
@@ -1,6 +1,6 @@
 use bulletproofs::{BulletproofGens, PedersenGens};
-use curve25519_dalek::scalar::Scalar;
 use curve25519_dalek::constants::RISTRETTO_BASEPOINT_COMPRESSED;
+use curve25519_dalek::scalar::Scalar;
 use hex;
 
 use zkvm::*;
@@ -44,7 +44,11 @@ impl ProgramHelper for Program {
     }
 
     fn input_helper(&mut self, qty: u64, flv: Scalar, pred: Predicate) -> &mut Self {
-        let anchor = Anchor::nonce([0u8;32], &Predicate::Opaque(RISTRETTO_BASEPOINT_COMPRESSED), 0);
+        let anchor = Anchor::nonce(
+            [0u8; 32],
+            &Predicate::Opaque(RISTRETTO_BASEPOINT_COMPRESSED),
+            0,
+        );
         let prev_output = Contract {
             anchor,
             payload: vec![PortableItem::Value(Value {

--- a/zkvm/tests/zkvm.rs
+++ b/zkvm/tests/zkvm.rs
@@ -34,7 +34,6 @@ impl ProgramHelper for Program {
             .push(dummy_block_id)
             .nonce()
             .sign_tx() // stack is clean
-            
             .push(Commitment::blinded_with_factor(qty, Scalar::from(1u64))) // stack: qty
             .var() // stack: qty-var
             .push(Commitment::unblinded(flv)) // stack: qty-var, flv
@@ -60,7 +59,7 @@ impl ProgramHelper for Program {
             })],
             predicate: pred,
         };
-        self.push(Input::new(prev_output)) // stack: input-data
+        self.push(Output::new(prev_output)) // stack: input-data
             .input() // stack: input-contract
             .sign_tx(); // stack: input-value
         self
@@ -179,7 +178,7 @@ fn issue() {
         Ok(txid) => {
             // Check txid
             assert_eq!(
-                "ee88427053ca9ee7726a633e39334415139dc7931a88a104456805f82f07f9a3",
+                "316f835973819a8cf6219010faf712bd17a1fe6fa2cc6350e4d96483b2065d82",
                 hex::encode(txid.0)
             );
         }


### PR DESCRIPTION
This introduces **anchors** and **contract IDs**, bringing back good ideas from TxVM, but doing it slightly differently. 

1. Each contract has a globally unique identifier, **contract ID**, which allows `delegate` to sign the unique instance in presence of reused predicate keys (see #172).
2. Uniqueness of contracts is provided by unique **anchors** contained within the contracts.
3. Nonce-based contracts have their anchor computed out of the nonce tuple `(predicate, blockid, exptime)`. Blockchain state machine tracks these nonce anchors to ensure their uniqueness.
4. UTXO ID is simply a contract ID.
5. Newly created contracts and outputs **consume VM's last anchor** and **set their ID as a new last anchor**.
6. Instead of a "uniqueness" flag, VM simply keeps and updates `Option<Anchor>`.
7. There is no longer "input structure", only "output structure", since the output is fully self-contained and unique.
8. `Input` type is renamed to `Output`: its purpose is to simply store contract ID alongside the contract w/o computing it by serializing the contract.

Different from TxVM:

1. Anchors are stored _per contract_, not _per value_. Values remain stateless and consisting purely of commitments to quantity and flavor.
2. All contracts are unique. In TxVM if the value was not changed, UTXO could remain unchanged, or even flip-flop between reused identifiers.
3. All-zero blockid is not allowed: in TxVM it was a special case to allow hypothetical cross-chain swaps with replayable transactions, which is not safe (also) because derived anchors cannot be guaranteed to be unique.

Closes #172.