### PR TITLE
zkvm/ops: replace instances of `Vec<Instruction>` with `Program`

### DIFF
--- a/token/src/token.rs
+++ b/token/src/token.rs
@@ -71,8 +71,8 @@ mod tests {
     use super::*;
     use bulletproofs::{BulletproofGens, PedersenGens};
     use zkvm::{
-        Entry, Instruction, Predicate, Program, Prover, Signature, Tx, TxHeader, TxID, TxLog,
-        VMError, VerificationKey, Verifier,
+        Entry, Predicate, Program, Prover, Signature, Tx, TxHeader, TxID, TxLog, VMError,
+        VerificationKey, Verifier,
     };
 
     #[test]
@@ -91,8 +91,7 @@ mod tests {
                     .push(Predicate::Key(VerificationKey::from_secret(&nonce_key)))
                     .nonce()
                     .sign_tx()
-            })
-            .to_vec();
+            });
             build(program, vec![issue_key, nonce_key]).unwrap()
         };
 
@@ -118,8 +117,7 @@ mod tests {
                     .push(Predicate::Key(VerificationKey::from_secret(&nonce_key)))
                     .nonce()
                     .sign_tx()
-            })
-            .to_vec();
+            });
             let (_, issue_txid, issue_txlog) =
                 build(issue_program, vec![issue_key, nonce_key]).unwrap();
 
@@ -129,7 +127,7 @@ mod tests {
                 _ => return assert!(false, "TxLog entry doesn't match: expected Output"),
             };
             Token::retire(&mut retire_program, issue_output, issue_txid);
-            build(retire_program.to_vec(), vec![dest_key]).unwrap()
+            build(retire_program, vec![dest_key]).unwrap()
         };
 
         // Verify tx
@@ -138,7 +136,7 @@ mod tests {
     }
 
     // Helper functions
-    fn build(program: Vec<Instruction>, keys: Vec<Scalar>) -> Result<(Tx, TxID, TxLog), VMError> {
+    fn build(program: Program, keys: Vec<Scalar>) -> Result<(Tx, TxID, TxLog), VMError> {
         let bp_gens = BulletproofGens::new(256, 1);
         let header = TxHeader {
             version: 0u64,

--- a/zkvm/src/ops.rs
+++ b/zkvm/src/ops.rs
@@ -362,8 +362,8 @@ impl Program {
 
     /// Creates a program from parsing the opaque data slice of encoded instructions.
     pub fn parse(data: &[u8]) -> Result<Self, VMError> {
-        let mut program = Self::new();
         SliceReader::parse(data, |r| {
+            let mut program = Self::new();
             while r.len() > 0 {
                 program.0.push(Instruction::parse(r)?);
             }

--- a/zkvm/src/ops.rs
+++ b/zkvm/src/ops.rs
@@ -288,17 +288,6 @@ impl Instruction {
             Instruction::Ext(x) => program.push(*x),
         };
     }
-
-    /// Encodes the iterator of instructions into a buffer.
-    pub fn encode_program<I>(iterator: I, program: &mut Vec<u8>)
-    where
-        I: IntoIterator,
-        I::Item: Borrow<Self>,
-    {
-        for i in iterator.into_iter() {
-            i.borrow().encode(program);
-        }
-    }
 }
 
 macro_rules! def_op {

--- a/zkvm/src/ops.rs
+++ b/zkvm/src/ops.rs
@@ -371,9 +371,32 @@ impl Program {
         program
     }
 
+    /// Creates a program from parsing the opaque data slice of encoded instructions.
+    pub fn parse(data: &[u8]) -> Result<Self, VMError> {
+        let mut program = Self::new();
+        SliceReader::parse(data, |r| {
+            while r.len() > 0 {
+                program.0.push(Instruction::parse(r)?);
+            }
+            Ok(program)
+        })
+    }
+
     /// Converts the program to a plain vector of instructions.
     pub fn to_vec(self) -> Vec<Instruction> {
         self.0
+    }
+
+    /// Returns the serialized length of the program.
+    pub fn serialized_length(&self) -> usize {
+        self.0.iter().map(|p| p.serialized_length()).sum()
+    }
+
+    /// Encodes a program into a buffer.
+    pub fn encode(&self, buf: &mut Vec<u8>) {
+        for i in self.0.iter() {
+            i.borrow().encode(buf);
+        }
     }
 
     /// Adds a `push` instruction with an immediate data type that can be converted into `Data`.

--- a/zkvm/tests/zkvm.rs
+++ b/zkvm/tests/zkvm.rs
@@ -103,7 +103,7 @@ fn issuance_helper() -> (Scalar, Predicate, Scalar) {
     (scalar, predicate, flavor)
 }
 
-fn test_helper(program: Vec<Instruction>, keys: &Vec<Scalar>) -> Result<TxID, VMError> {
+fn test_helper(program: Program, keys: &Vec<Scalar>) -> Result<TxID, VMError> {
     let (tx, _, _) = {
         // Build tx
         let bp_gens = BulletproofGens::new(256, 1);
@@ -142,12 +142,11 @@ fn issue_contract(
     issuance_pred: Predicate,
     nonce_pred: Predicate,
     output_pred: Predicate,
-) -> Vec<Instruction> {
+) -> Program {
     Program::build(|p| {
         p.issue_helper(qty, flv, issuance_pred, nonce_pred) // stack: issued-val
             .output_helper(output_pred) // stack: empty
     })
-    .to_vec()
 }
 
 #[test]
@@ -195,13 +194,12 @@ fn spend_1_1_contract(
     flv: Scalar,
     input_pred: Predicate,
     output_pred: Predicate,
-) -> Vec<Instruction> {
+) -> Program {
     Program::build(|p| {
         p.input_helper(input, flv, input_pred)
             .cloak_helper(1, vec![(output, flv)])
             .output_helper(output_pred)
     })
-    .to_vec()
 }
 
 #[test]
@@ -244,14 +242,13 @@ fn spend_1_2_contract(
     input_pred: Predicate,
     output_1_pred: Predicate,
     output_2_pred: Predicate,
-) -> Vec<Instruction> {
+) -> Program {
     Program::build(|p| {
         p.input_helper(input, flv, input_pred) // stack: input
             .cloak_helper(1, vec![(output_1, flv), (output_2, flv)]) // stack: output-1, output-2
             .output_helper(output_2_pred) // stack: output-1
             .output_helper(output_1_pred) // stack: empty
     })
-    .to_vec()
 }
 
 #[test]
@@ -298,14 +295,13 @@ fn spend_2_1_contract(
     input_1_pred: Predicate,
     input_2_pred: Predicate,
     output_pred: Predicate,
-) -> Vec<Instruction> {
+) -> Program {
     Program::build(|p| {
         p.input_helper(input_1, flv, input_1_pred) // stack: input-1
             .input_helper(input_2, flv, input_2_pred) // stack: input-1, input-2
             .cloak_helper(2, vec![(output, flv)]) // stack: output
             .output_helper(output_pred) // stack: empty
     })
-    .to_vec()
 }
 
 #[test]
@@ -354,7 +350,7 @@ fn spend_2_2_contract(
     input_2_pred: Predicate,
     output_1_pred: Predicate,
     output_2_pred: Predicate,
-) -> Vec<Instruction> {
+) -> Program {
     Program::build(|p| {
         p.input_helper(input_1, flv, input_1_pred) // stack: input-1
             .input_helper(input_2, flv, input_2_pred) // stack: input-1, input-2
@@ -362,7 +358,6 @@ fn spend_2_2_contract(
             .output_helper(output_2_pred) // stack: output-1
             .output_helper(output_1_pred) // stack: empty
     })
-    .to_vec()
 }
 
 #[test]
@@ -416,7 +411,7 @@ fn issue_and_spend_contract(
     input_pred: Predicate,
     output_1_pred: Predicate,
     output_2_pred: Predicate,
-) -> Vec<Instruction> {
+) -> Program {
     Program::build(|p| {
         p.issue_helper(issue_qty, flv, issuance_pred, nonce_pred) // stack: issued-val
             .input_helper(input_qty, flv, input_pred) // stack: issued-val, input-val
@@ -424,7 +419,6 @@ fn issue_and_spend_contract(
             .output_helper(output_2_pred) // stack: output-1
             .output_helper(output_1_pred) // stack: empty
     })
-    .to_vec()
 }
 
 #[test]


### PR DESCRIPTION
cleaning up instances of `Vec<Instruction>`, replacing with `Program`

Fixes #182 