### PR TITLE
zkvm/docs: blockchain spec

### DIFF
--- a/zkvm/docs/zkvm-blockchain.md
+++ b/zkvm/docs/zkvm-blockchain.md
@@ -1,0 +1,106 @@
+# ZkVM blockchain specification
+
+This is the specification for the ZkVM blockchain,
+a blockchain containing [ZkVM transactions](zkvm-spec.md).
+
+# Blockchain state
+
+The blockchain state contains:
+
+- `initialheader`: The initial block header (at height 1).
+- `tipheader`: The latest block header.
+- `utxos`: The IDs of all available [utxos](zkvm-spec.md#utxo).
+
+# Block header
+
+A block header contains:
+
+- `version`: integer version number, set to 1.
+- `height`: integer block height. Initial block has height 1. Height increases by 1 with each new block.
+- `previd`: ID of the preceding block. For the initial block (which has no predecessor), an all-zero string of 32 bytes.
+- `timestamp`: integer timestamp of the block in milliseconds since the Unix epoch: 00:00:00 UTC Jan 1, 1970.
+  Each new block must have a time strictly later than the block before it.
+- `txroot`: 32-byte merkle root hash of the transactions in the block.
+- `utxoroot`: 32-byte merkle root hash of the utxo set after applying all transactions in the block.
+
+# Block
+
+A block contains:
+
+- `header`: a [block header](#block-header).
+- `txs`: a list of [transactions](zkvm-spec.md#transaction).
+
+# Block ID
+
+A block ID is computed from a [block header](#block-header) using the [transcript](zkvm-spec.md#transcript) mechanism:
+
+```
+T = Transcript("ZkVM.blockheader")
+T.commit(LE64(version))
+T.commit(LE64(height))
+T.commit(previd)
+T.commit(LE64(timestamp))
+T.commit(txroot)
+T.commit(utxoroot)
+blockid = T.challenge_bytes("id")
+```
+
+# Make initial block
+
+# Join network
+
+# Validate block
+
+Inputs:
+- `block`, the block to validate.
+- `prevheader`, the header of the previous block.
+
+Output:
+- list of [txlog](zkvm-spec.md#transaction-log)+[txid](zkvm-spec.md#transaction-id) pairs,
+  one for each transaction in block.txs.
+
+Procedure:
+1. Verify `block.header.version >= prevheader.version`.
+2. Verify `block.header.height == prevheader.height+1`.
+3. Verify `block.header.previd` equals the [block ID](#block-id) of `prevheader`.
+4. Verify `block.header.timestamp > prevheader.timestamp`.
+5. For each transaction `tx` in block.txs:
+   1. Verify `tx.mintime == 0` or `tx.mintime >= block.header.timestamp`.
+   2. Verify `tx.maxtime == 0` or `tx.maxtime < block.header.timestamp`.
+   3. If `block.header.version == 1`, verify `tx.version == 1`.
+   4. [Execute](zkvm-spec.md#vm-execution) `tx` to produce transaction log `txlog`.
+   5. Compute [transaction ID](zkvm-spec.md#transaction-id) `txid` from `tx` and `txlog`.
+   6. Add the pair `txlog`+`txid` to the list of output pairs.
+
+# Apply block
+
+Inputs:
+- `block`, the block to apply.
+- `state`, the current [blockchain state](#blockchain-state).
+
+Output:
+- New blockchain state.
+
+Procedure:
+1. [Validate](#validate-block) `block` with `prevheader` set to `state.tipheader`.
+2. Let `state′` be `state`.
+3. For each txlog from the validation step, in order:
+   1. [Apply](#apply-transaction-log) the txlog to `state′` to produce `state′′`.
+   2. xxx error check
+   3. Set `state′ <- state′′`.
+4. Compute `utxoroot` from `state′.utxos`.
+5. Verify `block.header.utxoroot == utxoroot`.
+6. Set `state′.tipheader <- block.header`.
+7. Return `state′`.
+
+# Apply transaction
+
+Inputs:
+- `txlog`, a [transaction log](zkvm-spec.md#transaction-log).
+- `state`, a [blockchain state](#blockchain-state).
+
+Output:
+- New blockchain state.
+
+Procedure:
+- 

--- a/zkvm/docs/zkvm-blockchain.md
+++ b/zkvm/docs/zkvm-blockchain.md
@@ -113,12 +113,12 @@ mechanism:
 
 ```
 T = Transcript("ZkVM.blockheader")
-T.commit(LE64(version))
-T.commit(LE64(height))
-T.commit(previd)
-T.commit(LE64(timestampms))
-T.commit(txroot)
-T.commit(utxoroot)
+T.commit("version", LE64(version))
+T.commit("height", LE64(height))
+T.commit("previd", previd)
+T.commit("timestampms", LE64(timestampms))
+T.commit("txroot", txroot)
+T.commit("utxoroot", utxoroot)
 blockid = T.challenge_bytes("id")
 ```
 
@@ -162,7 +162,7 @@ Given a sorted list of n unique inputs,
 D[n] = {d(0), d(1), ..., d(n-1)}
 ```
 
-the MPTH is thus defined as follows:
+the MPTH is thus defined as follows.
 
 The hash of an empty Merkle patricia tree list is a 32-byte challenge string with the label `patricia.empty`:
 

--- a/zkvm/docs/zkvm-blockchain.md
+++ b/zkvm/docs/zkvm-blockchain.md
@@ -24,31 +24,19 @@ _TBD: add a consensus spec._
 
 The state of a ZkVM blockchain is given by the blockchain-state structure.
 Each node maintains a copy of this structure.
-As each new
-[block](#block)
-arrives,
-it is
-[applied](#apply-block)
-to the current state to produce a new,
+As each new [block](#block) arrives,
+it is [applied](#apply-block) to the current state to produce a new,
 updated state.
 
 The blockchain state contains:
 
-- `initialheader`:
-  The initial block header
+- `initialheader`: The initial block header
   (the header with height 1).
   This never changes.
-- `tipheader`:
-  The latest block header.
-- `utxos`:
-  The set of current
-  [utxo IDs](zkvm-spec.md#utxo).
-- `nonces`:
-  The set of current
-  [nonce anchors](zkvm-spec.md#nonce).
-- `refids`:
-  The set of recent
-  [block IDs](#block-id).
+- `tipheader`: The latest block header.
+- `utxos`: The set of current [utxo IDs](zkvm-spec.md#utxo).
+- `nonces`: The set of `<anchor,maxtime_ms>` pairs for all current [nonces](zkvm-spec.md#nonce).
+- `refids`: The set of recent [block IDs](#block-id).
   The size of this set is bounded by `block.header.refscount`.
   Block IDs in this set may be referenced by nonces.
 
@@ -56,12 +44,8 @@ The blockchain state contains:
 
 A block contains:
 
-- `header`:
-  a
-  [block header](#block-header).
-- `txs`:
-  a list of
-  [transactions](zkvm-spec.md#transaction).
+- `header`: A [block header](#block-header).
+- `txs`: A list of [transactions](zkvm-spec.md#transaction).
 
 The initial block
 (at height 1)
@@ -71,46 +55,29 @@ has an empty list of transactions.
 
 A block header contains:
 
-- `version`:
-  integer version number,
+- `version`: Integer version number,
   set to 1.
-- `height`:
-  integer block height.
+- `height`: Integer block height.
   Initial block has height 1.
   Height increases by 1 with each new block.
-- `previd`:
-  ID of the preceding block.
+- `previd`: ID of the preceding block.
   For the initial block
   (which has no predecessor),
   this is an all-zero string of 32 bytes.
-- `timestamp_ms`:
-  integer timestamp of the block in milliseconds since the Unix epoch:
-  00:00:00 UTC Jan 1,
-  1970.
+- `timestamp_ms`: Integer timestamp of the block in milliseconds since the Unix epoch:
+  00:00:00 UTC Jan 1, 1970.
   Each new block must have a time strictly later than the block before it.
-- `txroot`:
-  32-byte
-  [Merkle root hash](zkvm-spec.md#merkle-binary-tree)
-  of the transactions in the block.
-- `utxoroot`:
-  32-byte
-  [Merkle patricia root hash](#merkle-patricia-tree)
-  of the utxo set after applying all transactions in the block.
-- `nonceroot`:
-  32-byte
-  [Merkle patricia root hash](#merkle-patricia-tree)
-  of the nonce set after applying all transactions in the block.
-- `refscount`:
-  integer number of recent block IDs to store for reference.
+- `txroot`: 32-byte [Merkle root hash](zkvm-spec.md#merkle-binary-tree) of the transactions in the block.
+- `utxoroot`: 32-byte [Merkle patricia root hash](#merkle-patricia-tree) of the utxo set after applying all transactions in the block.
+- `nonceroot`: 32-byte [Merkle patricia root hash](#merkle-patricia-tree) of the nonce set after applying all transactions in the block.
+- `refscount`: Integer number of recent block IDs to store for reference.
   A new block may specify a lower `refscount` than its predecessor but may not increase it by more than 1.
+- `ext`: Variable-length byte string to contain future extensions.
+  Empty in version 1.
 
 ## Block ID
 
-A block ID is computed from a
-[block header](#block-header)
-using the
-[transcript](zkvm-spec.md#transcript)
-mechanism:
+A block ID is computed from a [block header](#block-header) using the [transcript](zkvm-spec.md#transcript) mechanism:
 
 ```
 T = Transcript("ZkVM.blockheader")
@@ -120,13 +87,15 @@ T.commit("previd", previd)
 T.commit("timestamp_ms", LE64(timestamp_ms))
 T.commit("txroot", txroot)
 T.commit("utxoroot", utxoroot)
+T.commit("nonceroot", nonceroot)
+T.commit("refscount", LE64(refscount))
+T.commit("ext", ext)
 blockid = T.challenge_bytes("id")
 ```
 
 ## Merkle patricia tree
 
-A Merkle patricia tree is similar to a
-[Merkle binary tree](zkvm-spec.md#merkle-binary-tree).
+A Merkle patricia tree is similar to a [Merkle binary tree](zkvm-spec.md#merkle-binary-tree).
 Its membership uniquely determines its shape.
 Each node hashes the subtrees beneath it.
 The root node’s hash is a commitment to the full membership of the tree.
@@ -135,13 +104,12 @@ It is possible to create and verify compact proofs of membership.
 Unlike a Merkle binary tree,
 a Merkle patricia tree is a radix tree
 (in which subtrees of a given node share a common prefix)
-with variable length branches that allow for efficient updates.
+with variable-length branches that allow for efficient updates.
 It is therefore preferable to a Merkle binary tree for large sets with frequent and comparatively small updates,
 specifically the utxo set and the nonce set.
 
 As with the Merkle binary tree,
-we define a Merkle patricia tree in terms of
-[transcripts](zkvm-spec.md#transcript).
+we define a Merkle patricia tree in terms of [transcripts](zkvm-spec.md#transcript).
 Leaves and nodes in the tree use the same instance of a transcript:
 
 ```
@@ -152,8 +120,8 @@ T = Transcript(<label>)
 
 The input to the *Merkle patricia tree hash*
 (MPTH)
-is a list of data entries;
-these entries will be hashed to form the leaves of the merkle hash tree.
+is a list of data entries.
+These entries will be hashed to form the leaves of the merkle hash tree.
 The output is a single 32-byte hash value.
 The input list must be prefix-free;
 that is,
@@ -173,7 +141,7 @@ MPTH(T, {}) = T.challenge_bytes("patricia.empty")
 ```
 
 To compute the hash of a list with one entry,
-commit it to the transcript with the label `"patricia.leaf"` and then generate a 32-byte challenge string with the same label:
+commit it to the transcript with the label `patricia.leaf` and then generate a 32-byte challenge string with the same label:
 
 ```
 T.commit("patricia.leaf", d(0))
@@ -187,11 +155,11 @@ To compute the hash of a list with two or more entries:
    `p` concatenated with the single bit 0).
 3. Let L be recursively defined as `MPTH(T, D[0:k])`
    (the hash of the first `k` elements of D).
-4. Commit `L` to `T` with the label `"patricia.left"`.
+4. Commit `L` to `T` with the label `patricia.left`.
 5. Let R be recursively defined as `MPTH(T, D[k:n])`
    (the hash of the remaining `n-k` elements of D).
-5. Commit `R` to `T` with the label `"patricia.right"`.
-6. Generate a 32-byte challenge string with the label `"patricia.node"`.
+5. Commit `R` to `T` with the label `patricia.right`.
+6. Generate a 32-byte challenge string with the label `patricia.node`.
 
 ```
 T.commit("patricia.left", MPTH(T, D[0:k]))
@@ -229,16 +197,11 @@ Procedure:
 1. [Make an initial block](#make-initial-block)
    `initialblock` from `timestamp_ms` and `refscount`.
 2. Return a blockchain state with its fields set as follows:
-   - `initialheader`:
-     `initialblock.header`
-   - `tipheader`:
-     `initialblock.header`
-   - `utxos`:
-     empty set
-   - `nonces`:
-     empty set
-   - `refids`:
-     empty set
+   - `initialheader`: `initialblock.header`
+   - `tipheader`: `initialblock.header`
+   - `utxos`: empty set
+   - `nonces`: empty set
+   - `refids`: empty set
 
 ## Make initial block
 
@@ -253,42 +216,25 @@ Inputs:
   uniqueness.
 
 Output:
-- a
-  [block](#block).
+- A [block](#block).
 
 Procedure:
-1. Compute `txroot`,
-   the root hash of an empty
-   [Merkle binary tree](zkvm-spec.md#merkle-binary-tree)
-   with label `transactions`.
-2. Compute `utxoroot`,
-   the root hash of an empty
-   [Merkle patricia tree](#merkle-patricia-tree)
-   with label `utxos`.
-3. Compute `nonceroot`,
-   the root hash of an empty
-   [Merkle patricia tree](#merkle-patricia-tree)
-   with label `nonces`.
+1. [Compute txroot](#compute-txroot) from an empty list of transactions.
+2. [Compute utxoroot](#compute-utxoroot) from an empty set of utxos.
+3. [Compute nonceroot](#compute-nonceroot) from an empty set of nonce anchors.
 4. Compute `header`,
    a
    [block header](#block-header)
    with its fields set as follows:
-   - `version`:
-     1
-   - `height`:
-     1
-   - `previd`:
-     all-zero string of 32-bytes
-   - `timestamp_ms`:
-     `timestamp_ms`
-   - `txroot`:
-     `txroot`
-   - `utxoroot`:
-     `utxoroot`
-   - `nonceroot`:
-     `nonceroot`
-   - `refscount`:
-     `refscount`
+   - `version`: 1
+   - `height`: 1
+   - `previd`: all-zero string of 32-bytes
+   - `timestamp_ms`: `timestamp_ms`
+   - `txroot`: `txroot`
+   - `utxoroot`: `utxoroot`
+   - `nonceroot`: `nonceroot`
+   - `refscount`: `refscount`
+   - `ext`: empty
 5. Return a block with `header` set to `header` and an empty `txs` list.
 
 ## Join existing network
@@ -296,9 +242,11 @@ Procedure:
 A new node starts here when joining a running network.
 It must either:
 - obtain all historical blocks, [applying](#apply-block) them one by one to reproduce the latest [blockchain state](#blockchain-state); or
-- obtain a recent copy of the blockchain state `state` and begin applying blocks beginning at `state.tipheader.height+1`.
+- obtain a recent copy of the blockchain state `state` from a trusted source
+  (e.g., another node that has already validated the full history of the blockchain)
+  and begin applying blocks beginning at `state.tipheader.height+1`.
 
-An obtained (as opposed to computed) blockchain state `state` may be partially validated by computing the [Merkle patricia root hash](#merkle-patricia-tree) of `state.utxos` using label `"utxos"` and verifying that it equals `state.header.utxoroot`.
+An obtained (as opposed to computed) blockchain state `state` may be partially validated by [computing the utxoroot](#compute-utxoroot) from `state.utxos` and verifying that it equals `state.header.utxoroot`.
 
 
 ## Validate block
@@ -314,28 +262,27 @@ Inputs:
   the header of the previous block.
 
 Output:
-- list of
-  [transaction logs](zkvm-spec.md#transaction-log),
+- list of [transaction logs](zkvm-spec.md#transaction-log),
   one for each transaction in block.txs.
 
 Procedure:
 1. Verify `block.header.version >= prevheader.version`.
-2. Verify `block.header.height == prevheader.height+1`.
-3. Verify `block.header.previd` equals the
+2. If `block.header.version == 1`, verify `block.header.ext` is empty.
+3. Verify `block.header.height == prevheader.height+1`.
+4. Verify `block.header.previd` equals the
    [block ID](#block-id)
    of `prevheader`.
-4. Verify `block.header.timestamp_ms > prevheader.timestamp_ms`.
-5. Verify `block.header.refscount >= 0` and `block.header.refscount <= prevheader.refscount + 1`.
-6. Compute `txroot`, the [Merkle root hash](zkvm-spec.md#merkle-binary-tree) of `block.txs`, using label `"transactions"`.
-7. Verify `txroot == block.header.txroot`.
-8. For each transaction `tx` in block.txs:
-   1. Verify `tx.mintimems == 0` or `tx.mintimems >= block.header.timestamp_ms`.
-   2. Verify `tx.maxtimems == 0` or `tx.maxtimems < block.header.timestamp_ms`.
-   3. If `block.header.version == 1`,
+5. Verify `block.header.timestamp_ms > prevheader.timestamp_ms`.
+6. Verify `block.header.refscount >= 0` and `block.header.refscount <= prevheader.refscount + 1`.
+7. [Compute txroot](#compute-txroot) from `block.txs`.
+8. Verify `txroot == block.header.txroot`.
+9. For each transaction `tx` in block.txs:
+   1. Verify `tx.mintime_ms <= block.header.timestamp_ms <= tx.maxtime_ms`.
+   2. If `block.header.version == 1`,
       verify `tx.version == 1`.
-   4. [Execute](zkvm-spec.md#vm-execution)
+   3. [Execute](zkvm-spec.md#vm-execution)
       `tx` to produce transaction log `txlog`.
-   5. Add `txlog` to the list of output logs.
+   4. Add `txlog` to the list of output logs.
 
 ## Apply block
 
@@ -345,25 +292,23 @@ Inputs:
 - `block`,
   the block to apply.
 - `state`,
-  the current
-  blockchain state.
+  the current blockchain state.
 
 Output:
-- New blockchain state.
+- New blockchain state `state′`.
 
 Procedure:
 1. [Validate](#validate-block)
    `block` with `prevheader` set to `state.tipheader`.
 2. Let `state′` be `state`.
-3. Remove items from `state′.nonces` where the expiration timestamp is earlier than `block.header.timestamp_ms`.
+3. Remove items from `state′.nonces` where `maxtime_ms < block.header.timestamp_ms`.
 4. For each txlog from the validation step,
    in order:
-   1. [Apply](#apply-transaction-log)
-      the txlog to `state′` to produce `state′′`.
+   1. [Apply the txlog](#apply-transaction-log) to `state′` to produce `state′′`.
    2. Set `state′ <- state′′`.
-5. Compute `utxoroot`, the [Merkle patricia root hash](#merkle-patricia-tree) of `state′.utxos` using label `"utxos"`.
+5. [Compute utxoroot](#compute-utxoroot) from `state′.utxos`.
 6. Verify `block.header.utxoroot == utxoroot`.
-7. Compute `nonceroot`, the Merkle patricia root hash of `state′.nonces` using label `"nonces"`.
+7. [Compute nonceroot](#compute-nonceroot) from the anchors in `state′.nonces`.
 8. Verify `block.header.nonceroot == nonceroot`.
 9. Set `state′.tipheader <- block.header`.
 10. Add `block.header` to the end of the `state′.refids` list.
@@ -374,33 +319,68 @@ Procedure:
 
 Inputs:
 - `txlog`,
-  a
-  [transaction log](zkvm-spec.md#transaction-log).
+  a [transaction log](zkvm-spec.md#transaction-log).
 - `state`,
-  a
-  [blockchain state](#blockchain-state).
+  a [blockchain state](#blockchain-state).
 
 Output:
-- New blockchain state.
+- New blockchain state `state′`.
 
 Procedure:
 1. Let `state′` be `state`.
-2. For each
-   [nonce entry](zkvm-spec.md#nonce-entry)
-   `n` in `txlog`:
+2. For each [nonce entry](zkvm-spec.md#nonce-entry) `n` in `txlog`:
    1. Verify `n.blockid` is one of the following:
       - The [ID](#block-id) of `state.initialheader`,
         or
       - One of the block ids in `state.refids`.
-   2. Verify `n` is _not_ in `state.nonces`.
-   3. Add `n` to `state′.nonces`.
-3. For each
-   [input entry](zkvm-spec.md#input-entry)
-   or
-   [output entry](zkvm-spec.md#output-entry)
-   in `txlog`:
+   2. Verify `n.nonce_anchor` is _not_ equal to any anchor in `state.nonces`.
+   3. Add the pair `<n.nonce_anchor,n.maxtime_ms>` to `state′.nonces`.
+3. For each [input entry](zkvm-spec.md#input-entry) or [output entry](zkvm-spec.md#output-entry) in `txlog`:
    1. If an input entry,
       verify its ID is in `state′.utxos`,
       then remove it.
    2. If an output entry,
       add its utxo ID to `state′.utxos`.
+4. Return `state′`.
+
+Note: utxos may be consumed in the same block,
+or even the same transaction,
+in which they are created.
+Implementations should therefore not try to reorder or batch step 3,
+at least not without taking extra care to cancel out such “local pairs” first.
+
+## Compute txroot
+
+Input:
+- Ordered list `txs` of [transactions](zkvm-spec.md#transaction).
+
+Output:
+- [Merkle root hash](zkvm-spec.md#merkle-binary-tree) of the transaction list.
+
+Procedure:
+1. Create a [transcript](zkvm-spec.md#transcript) `T` with label `transactions`.
+2. Return `MerkleHash(T, txs)`.
+
+## Compute utxoroot
+
+Input:
+- Unordered set `utxos` of [utxo IDs](zkvm-spec.md#utxo).
+
+Output:
+- [Merkle patricia root hash](#merkle-patricia-tree) of the given utxos.
+
+Procedure:
+1. Create a [transcript](zkvm-spec.md#transcript) `T` with label `utxos`.
+2. Return `MPTH(T, utxos)`.
+
+## Compute nonceroot
+
+Input:
+- Unordered set `nonces` of [nonce anchors](zkvm-spec.md#nonce).
+
+Output:
+- [Merkle patricia root hash](#merkle-patricia-tree) of the given nonce anchors.
+
+Procedure:
+1. Create a [transcript](zkvm-spec.md#transcript) `T` with label `nonces`.
+2. Return `MPTH(T, nonces)`.

--- a/zkvm/docs/zkvm-blockchain.md
+++ b/zkvm/docs/zkvm-blockchain.md
@@ -69,11 +69,11 @@ A block header contains:
   1970.
   Each new block must have a time strictly later than the block before it.
 - `txroot`:
-  32-byte merkle root hash of the transactions in the block.
+  32-byte [Merkle root hash](zkvm-spec.md#merkle-binary-tree) of the transactions in the block.
 - `utxoroot`:
-  32-byte merkle root hash of the utxo set after applying all transactions in the block.
+  32-byte Merkle patricia root hash of the utxo set after applying all transactions in the block.
 - `nonceroot`:
-  32-byte merkle root hash of the nonce set after applying all transactions in the block.
+  32-byte Merkle patricia root hash of the nonce set after applying all transactions in the block.
 - `refscount`:
   integer number of recent block IDs to store for reference.
   A new block may specify a lower `refscount` than its predecessor but may not increase it by more than 1.
@@ -97,8 +97,26 @@ T.commit(utxoroot)
 blockid = T.challenge_bytes("id")
 ```
 
-
 # Procedures
+
+## Merkle patricia tree
+
+A Merkle patricia tree is similar to a Merkle binary tree.
+Each node hashes the subtrees beneath it.
+The root node’s hash is a commitment to the full membership of the tree.
+It is possible to create and verify compact proofs of membership.
+
+Unlike a Merkle binary tree,
+a Merkle patricia tree is a radix tree
+(in which subtrees of a given node share a common prefix)
+with variable length branches that allow for efficient updates.
+It is therefore preferable to a Merkle binary tree for sets with churn:
+the utxo set and the nonce set.
+
+As with the
+[Merkle binary tree](zkvm-spec.md#merkle-binary-tree),
+we define a Merkle patricia tree in terms of
+[transcripts](zkvm-spec.md#transcript).
 
 ## Make initial block
 

--- a/zkvm/docs/zkvm-blockchain.md
+++ b/zkvm/docs/zkvm-blockchain.md
@@ -5,23 +5,37 @@ a blockchain containing
 [ZkVM transactions](zkvm-spec.md).
 
 Nodes participating in a ZkVM blockchain network must implement the data types and perform the procedures described in this document.
+Specifically:
 
-This document does not describe the consensus mechanism for a ZkVM blockchain network.
+- Each node maintains a [blockchain state](#blockchain-state).
+- A node creating a new ZkVM network performs the [start new network](#start-new-network) procedure.
+- A node joining an existing ZkVM network performance the [join existing network](#join-existing-network) procedure.
+- Each node performs the [apply block](#apply-block) procedure on the arrival of each new block.
+
+This document does not describe the consensus mechanism,
+which governs the production of authoritative blocks for the blockchain.
+
+_TBD: add a consensus spec._
 
 # Data types
 
 ## Blockchain state
 
 The state of a ZkVM blockchain is given by the blockchain-state structure.
-As each new [block](#block) arrives,
-it is [applied](#apply-block) to the current state to produce an new,
+Each node maintains a copy of this structure.
+As each new
+[block](#block)
+arrives,
+it is
+[applied](#apply-block)
+to the current state to produce an new,
 updated state.
 
 The blockchain state contains:
 
 - `initialheader`:
   The initial block header
-  (at height 1).
+  (the header with height 1).
   This never changes.
 - `tipheader`:
   The latest block header.
@@ -48,7 +62,9 @@ A block contains:
   a list of
   [transactions](zkvm-spec.md#transaction).
 
-The initial block (at height 1) has an empty list of transactions.
+The initial block
+(at height 1)
+has an empty list of transactions.
 
 ## Block header
 
@@ -72,11 +88,17 @@ A block header contains:
   1970.
   Each new block must have a time strictly later than the block before it.
 - `txroot`:
-  32-byte [Merkle root hash](zkvm-spec.md#merkle-binary-tree) of the transactions in the block.
+  32-byte
+  [Merkle root hash](zkvm-spec.md#merkle-binary-tree)
+  of the transactions in the block.
 - `utxoroot`:
-  32-byte [Merkle patricia root hash](#merkle-patricia-tree) of the utxo set after applying all transactions in the block.
+  32-byte
+  [Merkle patricia root hash](#merkle-patricia-tree)
+  of the utxo set after applying all transactions in the block.
 - `nonceroot`:
-  32-byte [Merkle patricia root hash](#merkle-patricia-tree) of the nonce set after applying all transactions in the block.
+  32-byte
+  [Merkle patricia root hash](#merkle-patricia-tree)
+  of the nonce set after applying all transactions in the block.
 - `refscount`:
   integer number of recent block IDs to store for reference.
   A new block may specify a lower `refscount` than its predecessor but may not increase it by more than 1.
@@ -102,7 +124,8 @@ blockid = T.challenge_bytes("id")
 
 ## Merkle patricia tree
 
-A Merkle patricia tree is similar to a [Merkle binary tree](zkvm-spec.md#merkle-binary-tree).
+A Merkle patricia tree is similar to a
+[Merkle binary tree](zkvm-spec.md#merkle-binary-tree).
 Each node hashes the subtrees beneath it.
 The root node’s hash is a commitment to the full membership of the tree.
 It is possible to create and verify compact proofs of membership.
@@ -134,7 +157,11 @@ The input list must be prefix-free;
 that is,
 no element can be a prefix of any other.
 Given a sorted list of n unique inputs,
-`D[n] = {d(0), d(1), ..., d(n-1)}`,
+
+```
+D[n] = {d(0), d(1), ..., d(n-1)}
+```
+
 the MPTH is thus defined as follows:
 
 The hash of an empty Merkle patricia tree list is a 32-byte challenge string with the label `patricia.empty`:
@@ -154,10 +181,13 @@ MPTH(T, {d{0)}) = T.challenge_bytes("patricia.leaf")
 To compute the hash of a list with two or more entries:
 1. Let the bit string `p` be the longest common prefix of all entries;
 2. Let k be the number of items with prefix `p||0`
-   (that is, `p` concatenated with the single bit 0).
-3. Let L be recursively defined as `MPTH(T, D[0:k])` (the hash of the first `k` elements of D).
+   (that is,
+   `p` concatenated with the single bit 0).
+3. Let L be recursively defined as `MPTH(T, D[0:k])`
+   (the hash of the first `k` elements of D).
 4. Commit `L` to `T` with the label `"patricia.left"`.
-5. Let R be recursively defined as `MPTH(T, D[k:n])` (the hash of the remaining `n-k` elements of D).
+5. Let R be recursively defined as `MPTH(T, D[k:n])`
+   (the hash of the remaining `n-k` elements of D).
 5. Commit `R` to `T` with the label `"patricia.right"`.
 6. Generate a 32-byte challenge string with the label `"patricia.node"`.
 
@@ -167,59 +197,113 @@ T.commit("patricia.right", MPTH(T, D[k:n]))
 MPTH(T, D) = T.challenge_bytes("patricia.node")
 ```
 
+
 # Procedures
+
+In the descriptions that follow,
+the word “verify” means to test whether a condition is true.
+If it’s false,
+all pending procedures abort and a failure result is returned.
 
 ## Start new network
 
+A node starts here when creating a new blockchain network.
+Its [blockchain state](#blockchain-state) is set to the result of the procedure.
+
 Inputs:
-- `timestampms`, the current time as a number of milliseconds since the Unix epoch:
+- `timestampms`,
+  the current time as a number of milliseconds since the Unix epoch:
   00:00:00 UTC Jan 1,
   1970.
-- `refscount`, the number of recent block ids to cache for [nonce](zkvm-spec.md#nonce) uniqueness.
+- `refscount`,
+  the number of recent block ids to cache for
+  [nonce](zkvm-spec.md#nonce)
+  uniqueness.
 
 Output:
-- [Blockchain state](#blockchain-state).
+- Blockchain state.
 
 Procedure:
-1. [Make an initial block](#make-initial-block) `initialblock` from `timestampms` and `refscount`.
+1. [Make an initial block](#make-initial-block)
+   `initialblock` from `timestampms` and `refscount`.
 2. Return a blockchain state with its fields set as follows:
-   - `initialheader`: `initialblock.header`
-   - `tipheader`: `initialblock.header`
-   - `utxos`: empty set
-   - `nonces`: empty set
-   - `refids`: empty set
+   - `initialheader`:
+     `initialblock.header`
+   - `tipheader`:
+     `initialblock.header`
+   - `utxos`:
+     empty set
+   - `nonces`:
+     empty set
+   - `refids`:
+     empty set
 
 ## Make initial block
 
 Inputs:
-- `timestampms`, the current time as a number of milliseconds since the Unix epoch:
+- `timestampms`,
+  the current time as a number of milliseconds since the Unix epoch:
   00:00:00 UTC Jan 1,
   1970.
-- `refscount`, the number of recent block ids to cache for [nonce](zkvm-spec.md#nonce) uniqueness.
+- `refscount`,
+  the number of recent block ids to cache for
+  [nonce](zkvm-spec.md#nonce)
+  uniqueness.
 
 Output:
-- a [block](#block).
+- a
+  [block](#block).
 
 Procedure:
-1. Compute `txroot`, the root hash of an empty [Merkle binary tree](zkvm-spec.md#merkle-binary-tree) with label `transactions`.
-2. Compute `utxoroot`, the root hash of an empty [Merkle patricia tree](#merkle-patricia-tree) with label `utxos`.
-3. Compute `nonceroot`, the root hash of an empty [Merkle patricia tree](#merkle-patricia-tree) with label `nonces`.
-4. Compute `header`, a [block header](#block-header) with its fields set as follows:
-   - `version`: 1
-   - `height`: 1
-   - `previd`: all-zero string of 32-bytes
-   - `timestampms`: `timestampms`
-   - `txroot`: `txroot`
-   - `utxoroot`: `utxoroot`
-   - `nonceroot`: `nonceroot`
-   - `refscount`: `refscount`
+1. Compute `txroot`,
+   the root hash of an empty
+   [Merkle binary tree](zkvm-spec.md#merkle-binary-tree)
+   with label `transactions`.
+2. Compute `utxoroot`,
+   the root hash of an empty
+   [Merkle patricia tree](#merkle-patricia-tree)
+   with label `utxos`.
+3. Compute `nonceroot`,
+   the root hash of an empty
+   [Merkle patricia tree](#merkle-patricia-tree)
+   with label `nonces`.
+4. Compute `header`,
+   a
+   [block header](#block-header)
+   with its fields set as follows:
+   - `version`:
+     1
+   - `height`:
+     1
+   - `previd`:
+     all-zero string of 32-bytes
+   - `timestampms`:
+     `timestampms`
+   - `txroot`:
+     `txroot`
+   - `utxoroot`:
+     `utxoroot`
+   - `nonceroot`:
+     `nonceroot`
+   - `refscount`:
+     `refscount`
 5. Return a block with `header` set to `header` and an empty `txs` list.
 
 ## Join existing network
 
+A new node starts here when joining a running network.
+It must either:
+- obtain all historical blocks, [applying](#apply-block) them one by one to reproduce the latest [blockchain state](#blockchain-state); or
+- obtain a recent copy of the blockchain state `state` and begin applying blocks beginning at `state.tipheader.height+1`.
+
+An obtained (as opposed to computed) blockchain state `state` may be partially validated by computing the [Merkle patricia root hash](#merkle-patricia-tree) of `state.utxos` using label `"utxos"` and verifying that it equals `state.header.utxoroot`.
 
 
 ## Validate block
+
+Validating a block checks it for correctness outside the context of a particular [blockchain state](#blockchain-state).
+
+Additional correctness checks against a particular blockchain state happen during the [apply block](#apply-block) procedure.
 
 Inputs:
 - `block`,
@@ -240,7 +324,9 @@ Procedure:
    of `prevheader`.
 4. Verify `block.header.timestampms > prevheader.timestampms`.
 5. Verify `block.header.refscount >= 0` and `block.header.refscount <= prevheader.refscount + 1`.
-5. For each transaction `tx` in block.txs:
+6. Compute `txroot`, the [Merkle root hash](zkvm-spec.md#merkle-binary-tree) of `block.txs`, using label `"transactions"`.
+7. Verify `txroot == block.header.txroot`.
+8. For each transaction `tx` in block.txs:
    1. Verify `tx.mintimems == 0` or `tx.mintimems >= block.header.timestampms`.
    2. Verify `tx.maxtimems == 0` or `tx.maxtimems < block.header.timestampms`.
    3. If `block.header.version == 1`,
@@ -251,12 +337,14 @@ Procedure:
 
 ## Apply block
 
+Applying a block causes a node to replace its [blockchain state](#blockchain-state) with the updated state that results.
+
 Inputs:
 - `block`,
   the block to apply.
 - `state`,
   the current
-  [blockchain state](#blockchain-state).
+  blockchain state.
 
 Output:
 - New blockchain state.
@@ -265,15 +353,15 @@ Procedure:
 1. [Validate](#validate-block)
    `block` with `prevheader` set to `state.tipheader`.
 2. Let `state′` be `state`.
-3. Remove items from `state′.nonces` where the expiration timestamp is less than `block.header.timestampms`.
+3. Remove items from `state′.nonces` where the expiration timestamp is earlier than `block.header.timestampms`.
 4. For each txlog from the validation step,
    in order:
    1. [Apply](#apply-transaction-log)
       the txlog to `state′` to produce `state′′`.
    2. Set `state′ <- state′′`.
-5. Compute `utxoroot` from `state′.utxos`.
+5. Compute `utxoroot`, the [Merkle patricia root hash](#merkle-patricia-tree) of `state′.utxos` using label `"utxos"`.
 6. Verify `block.header.utxoroot == utxoroot`.
-7. Compute `nonceroot` from `state′.nonces`.
+7. Compute `nonceroot`, the Merkle patricia root hash of `state′.nonces` using label `"nonces"`.
 8. Verify `block.header.nonceroot == nonceroot`.
 9. Set `state′.tipheader <- block.header`.
 10. Add `block.header` to the end of the `state′.refids` list.
@@ -312,6 +400,7 @@ Procedure:
    [output entry](zkvm-spec.md#output-entry)
    in `txlog`:
    1. If an input entry,
-      remove its utxo ID from `state′.utxos`.
+      verify its ID is in `state′.utxos`,
+      then remove it.
    2. If an output entry,
       add its utxo ID to `state′.utxos`.

--- a/zkvm/docs/zkvm-blockchain.md
+++ b/zkvm/docs/zkvm-blockchain.md
@@ -22,14 +22,15 @@ The blockchain state contains:
 - `initialheader`:
   The initial block header
   (at height 1).
+  This never changes.
 - `tipheader`:
   The latest block header.
 - `utxos`:
-  The IDs of all available
-  [utxos](zkvm-spec.md#utxo).
+  The set of current
+  [utxo IDs](zkvm-spec.md#utxo).
 - `nonces`:
   The set of current
-  [nonces](#nonce).
+  [nonce anchors](zkvm-spec.md#nonce).
 - `refids`:
   The set of recent
   [block IDs](#block-id).
@@ -65,7 +66,7 @@ A block header contains:
   For the initial block
   (which has no predecessor),
   this is an all-zero string of 32 bytes.
-- `timestamp`:
+- `timestampms`:
   integer timestamp of the block in milliseconds since the Unix epoch:
   00:00:00 UTC Jan 1,
   1970.
@@ -73,9 +74,9 @@ A block header contains:
 - `txroot`:
   32-byte [Merkle root hash](zkvm-spec.md#merkle-binary-tree) of the transactions in the block.
 - `utxoroot`:
-  32-byte Merkle patricia root hash of the utxo set after applying all transactions in the block.
+  32-byte [Merkle patricia root hash](#merkle-patricia-tree) of the utxo set after applying all transactions in the block.
 - `nonceroot`:
-  32-byte Merkle patricia root hash of the nonce set after applying all transactions in the block.
+  32-byte [Merkle patricia root hash](#merkle-patricia-tree) of the nonce set after applying all transactions in the block.
 - `refscount`:
   integer number of recent block IDs to store for reference.
   A new block may specify a lower `refscount` than its predecessor but may not increase it by more than 1.
@@ -93,17 +94,15 @@ T = Transcript("ZkVM.blockheader")
 T.commit(LE64(version))
 T.commit(LE64(height))
 T.commit(previd)
-T.commit(LE64(timestamp))
+T.commit(LE64(timestampms))
 T.commit(txroot)
 T.commit(utxoroot)
 blockid = T.challenge_bytes("id")
 ```
 
-# Procedures
-
 ## Merkle patricia tree
 
-A Merkle patricia tree is similar to a Merkle binary tree.
+A Merkle patricia tree is similar to a [Merkle binary tree](zkvm-spec.md#merkle-binary-tree).
 Each node hashes the subtrees beneath it.
 The root node’s hash is a commitment to the full membership of the tree.
 It is possible to create and verify compact proofs of membership.
@@ -112,11 +111,10 @@ Unlike a Merkle binary tree,
 a Merkle patricia tree is a radix tree
 (in which subtrees of a given node share a common prefix)
 with variable length branches that allow for efficient updates.
-It is therefore preferable to a Merkle binary tree for sets with churn:
-the utxo set and the nonce set.
+It is therefore preferable to a Merkle binary tree for sets with churn
+specifically the utxo set and the nonce set.
 
-As with the
-[Merkle binary tree](zkvm-spec.md#merkle-binary-tree),
+As with the Merkle binary tree,
 we define a Merkle patricia tree in terms of
 [transcripts](zkvm-spec.md#transcript).
 Leaves and nodes in the tree use the same instance of a transcript:
@@ -169,10 +167,57 @@ T.commit("patricia.right", MPTH(T, D[k:n]))
 MPTH(T, D) = T.challenge_bytes("patricia.node")
 ```
 
+# Procedures
+
+## Start new network
+
+Inputs:
+- `timestampms`, the current time as a number of milliseconds since the Unix epoch:
+  00:00:00 UTC Jan 1,
+  1970.
+- `refscount`, the number of recent block ids to cache for [nonce](zkvm-spec.md#nonce) uniqueness.
+
+Output:
+- [Blockchain state](#blockchain-state).
+
+Procedure:
+1. [Make an initial block](#make-initial-block) `initialblock` from `timestampms` and `refscount`.
+2. Return a blockchain state with its fields set as follows:
+   - `initialheader`: `initialblock.header`
+   - `tipheader`: `initialblock.header`
+   - `utxos`: empty set
+   - `nonces`: empty set
+   - `refids`: empty set
 
 ## Make initial block
 
-## Join network
+Inputs:
+- `timestampms`, the current time as a number of milliseconds since the Unix epoch:
+  00:00:00 UTC Jan 1,
+  1970.
+- `refscount`, the number of recent block ids to cache for [nonce](zkvm-spec.md#nonce) uniqueness.
+
+Output:
+- a [block](#block).
+
+Procedure:
+1. Compute `txroot`, the root hash of an empty [Merkle binary tree](zkvm-spec.md#merkle-binary-tree) with label `transactions`.
+2. Compute `utxoroot`, the root hash of an empty [Merkle patricia tree](#merkle-patricia-tree) with label `utxos`.
+3. Compute `nonceroot`, the root hash of an empty [Merkle patricia tree](#merkle-patricia-tree) with label `nonces`.
+4. Compute `header`, a [block header](#block-header) with its fields set as follows:
+   - `version`: 1
+   - `height`: 1
+   - `previd`: all-zero string of 32-bytes
+   - `timestampms`: `timestampms`
+   - `txroot`: `txroot`
+   - `utxoroot`: `utxoroot`
+   - `nonceroot`: `nonceroot`
+   - `refscount`: `refscount`
+5. Return a block with `header` set to `header` and an empty `txs` list.
+
+## Join existing network
+
+
 
 ## Validate block
 
@@ -193,11 +238,11 @@ Procedure:
 3. Verify `block.header.previd` equals the
    [block ID](#block-id)
    of `prevheader`.
-4. Verify `block.header.timestamp > prevheader.timestamp`.
+4. Verify `block.header.timestampms > prevheader.timestampms`.
 5. Verify `block.header.refscount >= 0` and `block.header.refscount <= prevheader.refscount + 1`.
 5. For each transaction `tx` in block.txs:
-   1. Verify `tx.mintime == 0` or `tx.mintime >= block.header.timestamp`.
-   2. Verify `tx.maxtime == 0` or `tx.maxtime < block.header.timestamp`.
+   1. Verify `tx.mintimems == 0` or `tx.mintimems >= block.header.timestampms`.
+   2. Verify `tx.maxtimems == 0` or `tx.maxtimems < block.header.timestampms`.
    3. If `block.header.version == 1`,
       verify `tx.version == 1`.
    4. [Execute](zkvm-spec.md#vm-execution)
@@ -220,7 +265,7 @@ Procedure:
 1. [Validate](#validate-block)
    `block` with `prevheader` set to `state.tipheader`.
 2. Let `state′` be `state`.
-3. Remove items from `state′.nonces` where the expiration timestamp is less than `block.header.timestamp`.
+3. Remove items from `state′.nonces` where the expiration timestamp is less than `block.header.timestampms`.
 4. For each txlog from the validation step,
    in order:
    1. [Apply](#apply-transaction-log)

--- a/zkvm/docs/zkvm-blockchain.md
+++ b/zkvm/docs/zkvm-blockchain.md
@@ -9,7 +9,7 @@ Specifically:
 
 - Each node maintains a [blockchain state](#blockchain-state).
 - A node creating a new ZkVM network performs the [start new network](#start-new-network) procedure.
-- A node joining an existing ZkVM network performance the [join existing network](#join-existing-network) procedure.
+- A node joining an existing ZkVM network performs the [join existing network](#join-existing-network) procedure.
 - Each node performs the [apply block](#apply-block) procedure on the arrival of each new block.
 
 This document does not describe the mechanism for producing blocks from pending transactions,

--- a/zkvm/docs/zkvm-blockchain.md
+++ b/zkvm/docs/zkvm-blockchain.md
@@ -1,45 +1,90 @@
 # ZkVM blockchain specification
 
 This is the specification for the ZkVM blockchain,
-a blockchain containing [ZkVM transactions](zkvm-spec.md).
+a blockchain containing
+[ZkVM transactions](zkvm-spec.md).
 
-# Blockchain state
+Nodes participating in a ZkVM blockchain network must implement the data types and perform the procedures described in this document.
+
+This document does not describe the consensus mechanism for a ZkVM network.
+
+# Data types
+
+## Blockchain state
+
+The state of a ZkVM blockchain is given by the blockchain-state structure.
+As each new [block](#block) arrives,
+it is [applied](#apply-block) to the current state to produce an new,
+updated state.
 
 The blockchain state contains:
 
-- `initialheader`: The initial block header (at height 1).
-- `tipheader`: The latest block header.
-- `utxos`: The IDs of all available [utxos](zkvm-spec.md#utxo).
-- `nonces`: The set of current [nonces](#nonce).
-- `refids`: The set of recent [block IDs](#block-id).
+- `initialheader`:
+  The initial block header
+  (at height 1).
+- `tipheader`:
+  The latest block header.
+- `utxos`:
+  The IDs of all available
+  [utxos](zkvm-spec.md#utxo).
+- `nonces`:
+  The set of current
+  [nonces](#nonce).
+- `refids`:
+  The set of recent
+  [block IDs](#block-id).
   The size of this set is bounded by `block.header.refscount`.
   Block IDs in this set may be referenced by nonces.
 
-# Block header
-
-A block header contains:
-
-- `version`: integer version number, set to 1.
-- `height`: integer block height. Initial block has height 1. Height increases by 1 with each new block.
-- `previd`: ID of the preceding block. For the initial block (which has no predecessor), an all-zero string of 32 bytes.
-- `timestamp`: integer timestamp of the block in milliseconds since the Unix epoch: 00:00:00 UTC Jan 1, 1970.
-  Each new block must have a time strictly later than the block before it.
-- `txroot`: 32-byte merkle root hash of the transactions in the block.
-- `utxoroot`: 32-byte merkle root hash of the utxo set after applying all transactions in the block.
-- `nonceroot`: 32-byte merkle root hash of the nonce set after applying all transactions in the block.
-- `refscount`: integer number of recent block IDs to store for reference.
-  A new block may specify a lower `refscount` than its predecessor but may not increase it by more than 1.
-
-# Block
+## Block
 
 A block contains:
 
-- `header`: a [block header](#block-header).
-- `txs`: a list of [transactions](zkvm-spec.md#transaction).
+- `header`:
+  a
+  [block header](#block-header).
+- `txs`:
+  a list of
+  [transactions](zkvm-spec.md#transaction).
 
-# Block ID
+## Block header
 
-A block ID is computed from a [block header](#block-header) using the [transcript](zkvm-spec.md#transcript) mechanism:
+A block header contains:
+
+- `version`:
+  integer version number,
+  set to 1.
+- `height`:
+  integer block height.
+  Initial block has height 1.
+  Height increases by 1 with each new block.
+- `previd`:
+  ID of the preceding block.
+  For the initial block
+  (which has no predecessor),
+  an all-zero string of 32 bytes.
+- `timestamp`:
+  integer timestamp of the block in milliseconds since the Unix epoch:
+  00:00:00 UTC Jan 1,
+  1970.
+  Each new block must have a time strictly later than the block before it.
+- `txroot`:
+  32-byte merkle root hash of the transactions in the block.
+- `utxoroot`:
+  32-byte merkle root hash of the utxo set after applying all transactions in the block.
+- `nonceroot`:
+  32-byte merkle root hash of the nonce set after applying all transactions in the block.
+- `refscount`:
+  integer number of recent block IDs to store for reference.
+  A new block may specify a lower `refscount` than its predecessor but may not increase it by more than 1.
+
+## Block ID
+
+A block ID is computed from a
+[block header](#block-header)
+using the
+[transcript](zkvm-spec.md#transcript)
+mechanism:
 
 ```
 T = Transcript("ZkVM.blockheader")
@@ -52,48 +97,64 @@ T.commit(utxoroot)
 blockid = T.challenge_bytes("id")
 ```
 
-# Make initial block
 
-# Join network
+# Procedures
 
-# Validate block
+## Make initial block
+
+## Join network
+
+## Validate block
 
 Inputs:
-- `block`, the block to validate.
-- `prevheader`, the header of the previous block.
+- `block`,
+  the block to validate.
+- `prevheader`,
+  the header of the previous block.
 
 Output:
-- list of [transaction logs](zkvm-spec.md#transaction-log),
+- list of
+  [transaction logs](zkvm-spec.md#transaction-log),
   one for each transaction in block.txs.
 
 Procedure:
 1. Verify `block.header.version >= prevheader.version`.
 2. Verify `block.header.height == prevheader.height+1`.
-3. Verify `block.header.previd` equals the [block ID](#block-id) of `prevheader`.
+3. Verify `block.header.previd` equals the
+   [block ID](#block-id)
+   of `prevheader`.
 4. Verify `block.header.timestamp > prevheader.timestamp`.
 5. Verify `block.header.refscount >= 0` and `block.header.refscount <= prevheader.refscount + 1`.
 5. For each transaction `tx` in block.txs:
    1. Verify `tx.mintime == 0` or `tx.mintime >= block.header.timestamp`.
    2. Verify `tx.maxtime == 0` or `tx.maxtime < block.header.timestamp`.
-   3. If `block.header.version == 1`, verify `tx.version == 1`.
-   4. [Execute](zkvm-spec.md#vm-execution) `tx` to produce transaction log `txlog`.
+   3. If `block.header.version == 1`,
+      verify `tx.version == 1`.
+   4. [Execute](zkvm-spec.md#vm-execution)
+      `tx` to produce transaction log `txlog`.
    5. Add `txlog` to the list of output logs.
 
-# Apply block
+## Apply block
 
 Inputs:
-- `block`, the block to apply.
-- `state`, the current [blockchain state](#blockchain-state).
+- `block`,
+  the block to apply.
+- `state`,
+  the current
+  [blockchain state](#blockchain-state).
 
 Output:
 - New blockchain state.
 
 Procedure:
-1. [Validate](#validate-block) `block` with `prevheader` set to `state.tipheader`.
+1. [Validate](#validate-block)
+   `block` with `prevheader` set to `state.tipheader`.
 2. Let `state′` be `state`.
 3. Remove items from `state′.nonces` where the expiration timestamp is less than `block.header.timestamp`.
-4. For each txlog from the validation step, in order:
-   1. [Apply](#apply-transaction-log) the txlog to `state′` to produce `state′′`.
+4. For each txlog from the validation step,
+   in order:
+   1. [Apply](#apply-transaction-log)
+      the txlog to `state′` to produce `state′′`.
    2. Set `state′ <- state′′`.
 5. Compute `utxoroot` from `state′.utxos`.
 6. Verify `block.header.utxoroot == utxoroot`.
@@ -104,24 +165,38 @@ Procedure:
 11. Prune `state′.refids` to the number of items specified by `block.header.refscount` by removing the oldest IDs.
 12. Return `state′`.
 
-# Apply transaction log
+## Apply transaction log
 
 Inputs:
-- `txlog`, a [transaction log](zkvm-spec.md#transaction-log).
-- `state`, a [blockchain state](#blockchain-state).
+- `txlog`,
+  a
+  [transaction log](zkvm-spec.md#transaction-log).
+- `state`,
+  a
+  [blockchain state](#blockchain-state).
 
 Output:
 - New blockchain state.
 
 Procedure:
 1. Let `state′` be `state`.
-2. For each [nonce entry](zkvm-spec.md#nonce-entry) `n` in `txlog`:
+2. For each
+   [nonce entry](zkvm-spec.md#nonce-entry)
+   `n` in `txlog`:
    1. Verify `n.blockid` is one of the following:
-      - An all-zero 32-byte string, or
-      - The ID of the initial block, or
+      - An all-zero 32-byte string,
+        or
+      - The ID of the initial block,
+        or
       - One of the block ids in `state.refids`.
    2. Verify `n` is _not_ in `state.nonces`.
    3. Add `n` to `state′.nonces`.
-3. For each [input entry](zkvm-spec.md#input-entry) or [output entry](zkvm-spec.md#output-entry) in `txlog`:
-   1. If an input entry, remove its utxo ID from `state′.utxos`.
-   2. If an output entry, add its utxo ID to `state′.utxos`.
+3. For each
+   [input entry](zkvm-spec.md#input-entry)
+   or
+   [output entry](zkvm-spec.md#output-entry)
+   in `txlog`:
+   1. If an input entry,
+      remove its utxo ID from `state′.utxos`.
+   2. If an output entry,
+      add its utxo ID to `state′.utxos`.

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -1,4 +1,4 @@
-# ZkVM specification
+# ZkVM transaction specification
 
 This is the specification for ZkVM, the zero-knowledge transaction virtual machine.
 
@@ -378,7 +378,8 @@ Verification keys are used to construct [predicates](#predicate) and verify [sig
 ### Time bounds
 
 Each transaction is explicitly bound to a range of _minimum_ and _maximum_ time.
-Each bound is in _seconds_ since Jan 1st, 1970 (UTC), represented by an unsigned 64-bit integer.
+Each bound is in _milliseconds_ since the Unix epoch: 00:00:00 on 1 Jan 1970 (UTC),
+represented by an unsigned 64-bit integer.
 Time bounds are available in the transaction as [expressions](#expression-type) provided by the instructions
 [`mintime`](#mintime) and [`maxtime`](#maxtime).
 
@@ -395,11 +396,11 @@ Transcript is used throughout ZkVM to generate challenge [scalars](#scalar) and 
 Transcripts have the following operations, each taking a label for domain separation:
 
 1. **Initialize** transcript:
-    ```    
+    ```
     T := Transcript(label)
     ```
 2. **Commit bytes** of arbitrary length:
-    ```    
+    ```
     T.commit(label, bytes)
     ```
 3. **Challenge bytes**

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -1769,8 +1769,7 @@ To _initiate_ a force-close, the program `P1` does:
 
 To construct such program `P1`, users first agree on the final distribution of balances via the program `P2`.
 
-The final-distribution program `P2`:
-1. Checks that `tx.mintime >= exptime` (can be done via `range:24(tx.mintime - exptime)` which gives 6-month resolution for the expiration time)
+The final-distribution program `P2`:1. Checks that `tx.mintime >= exptime` (can be done via `range:24(tx.mintime - exptime)` which gives 6-month resolution for the expiration time)
 2. Creates `borrow`/`output` combinations for each party with hard-coded predicate for each output.
 3. Leaves the payload value and negatives from `borrow` on the stack to be consumed by the `cloak` instruction.
 

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -29,10 +29,10 @@ pub struct TxHeader {
     /// Version of the transaction
     pub version: u64,
 
-    /// Timestamp before which tx is invalid (sec)
+    /// Timestamp before which tx is invalid (in milliseconds since the Unix epoch)
     pub mintime: u64,
 
-    /// Timestamp after which tx is invalid (sec)
+    /// Timestamp after which tx is invalid (in milliseconds since the Unix epoch)
     pub maxtime: u64,
 }
 


### PR DESCRIPTION
Updates `zkvm-spec.md` to use millisecond-based timestamps.