### PR TITLE
keytree: derive intermediate pubkey

### DIFF
--- a/keytree/src/lib.rs
+++ b/keytree/src/lib.rs
@@ -135,7 +135,9 @@ mod tests {
         let seed = [0u8; 32];
         let mut rng = ChaChaRng::from_seed(seed);
         let xprv = Xprv::random(&mut rng);
-        let xpub = xprv.to_xpub().to_intermediate_key(customize);
+        let xpub = xprv.to_xpub().to_intermediate_key(|t| {
+            t.commit_u64("account_id", 42);
+        });
 
         // the following are hard-coded based on the previous seed
         let expected_dk = [

--- a/keytree/src/lib.rs
+++ b/keytree/src/lib.rs
@@ -48,6 +48,18 @@ impl Xprv {
     }
 }
 
+pub fn intermediate_key(xpub: &Xpub, label: &String, data: &String) -> Xpub {
+    // question: is the following kosher? https://doc.dalek.rs/merlin/struct.Transcript.html#note
+    let mut t = Transcript::new(b"Keytree.intermediate");
+    t.commit_bytes(b"pt", xpub.point.as_bytes());
+    t.commit_bytes(b"dk", &xpub.dk);
+
+    // provide the transcript to the user to commit an arbitrary derivation path or index
+    t.commit_bytes(label.as_bytes(), data.as_bytes());
+
+    unimplemented!();
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/keytree/src/lib.rs
+++ b/keytree/src/lib.rs
@@ -76,7 +76,7 @@ impl Xpub {
         Xpub {
             point,
             dk,
-            precompressed_pubkey,
+            precompressed_pubkey: point.compress(),
         }
     }
 }

--- a/keytree/src/lib.rs
+++ b/keytree/src/lib.rs
@@ -54,7 +54,7 @@ impl Xprv {
 
 impl Xpub {
     /// Returns a intermediate child pubkey.
-    pub fn to_intermediate_key(&self, customize: impl FnOnce(&mut Transcript)) -> Xpub {
+    pub fn derive_intermediate_key(&self, customize: impl FnOnce(&mut Transcript)) -> Xpub {
         let mut t = Transcript::new(b"Keytree.derivation");
         t.commit_bytes(b"pt", self.precompressed_pubkey.as_bytes());
         t.commit_bytes(b"dk", &self.dk);

--- a/keytree/src/lib.rs
+++ b/keytree/src/lib.rs
@@ -70,7 +70,7 @@ impl Xpub {
         let mut dk = [0u8; 32];
         t.challenge_bytes(b"dk", &mut dk);
 
-        let point = self.point + (f * &constants::RISTRETTO_BASEPOINT_POINT);
+        let child_point = self.point + (f * &constants::RISTRETTO_BASEPOINT_POINT);
         let precompressed_pubkey = point.compress();
 
         Xpub {

--- a/keytree/src/lib.rs
+++ b/keytree/src/lib.rs
@@ -67,7 +67,7 @@ impl Xpub {
         let f = t.challenge_scalar(b"f.intermediate");
 
         // squeeze a new derivation key
-        let mut dk = [0u8; 32];
+        let mut child_dk = [0u8; 32];
         t.challenge_bytes(b"dk", &mut dk);
 
         let child_point = self.point + (f * &constants::RISTRETTO_BASEPOINT_POINT);


### PR DESCRIPTION
This is my first stab at this function. A few outstanding questions: 

1. This function returns an Option because it calls a function that returns an Option and I wasn't sure what else to do.
2. Currently it only accepts Xpubs; I'd love a pointer on how to make it accept Xprvs too. I'm guessing something with generics? _has never see a generic before, :gopher:_
3. This note about not calling the Transcript directly has me a tad spooked: https://doc.dalek.rs/merlin/struct.Transcript.html#note
4. Is the function signature even right here? Among other things, I made it take a label which is a `&'static std::string::String` to satisfy some business about lifetimes. 