### PR TITLE
zkvm: serialize Tx object

### DIFF
--- a/zkvm/Cargo.toml
+++ b/zkvm/Cargo.toml
@@ -17,6 +17,7 @@ merlin = "1.0.1"
 rand = "0.6"
 subtle = "2"
 curve25519-dalek = { version = "1.0.1", features = ["serde"] }
+serde = { version = "1.0", features=["derive"] }
 
 
 [dependencies.bulletproofs]

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -1605,10 +1605,10 @@ A [Transaction](#transaction) is serialized as follows:
 
 ```
         SerializedTx = TxHeader || LE32(len(Program)) || Program || Signature || Proof
-        TxHeader = <24 bytes>
+        TxHeader = LE64(version) || LE64(mintime) || LE64(maxtime)
         Program = <len(Program) bytes>
         Signature = <64 bytes>
-        Proof = <14 * 32 + len(InnerProductProof) bytes>
+        Proof = <14·32 + len(InnerProductProof) bytes>
 ```
 
 ## Examples

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -57,7 +57,7 @@ ZkVM defines a procedural representation for blockchain transactions and the rul
     * [Constraint system instructions](#constraint-system-instructions)
     * [Value instructions](#value-instructions)
     * [Contract instructions](#contract-instructions)
-* [Transaction Encoding](#tx-encoding)
+* [Transaction Encoding](#transaction-encoding)
 * [Examples](#examples)
     * [Lock value example](#lock-value-example)
     * [Unlock value example](#unlock-value-example)

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -57,6 +57,7 @@ ZkVM defines a procedural representation for blockchain transactions and the rul
     * [Constraint system instructions](#constraint-system-instructions)
     * [Value instructions](#value-instructions)
     * [Contract instructions](#contract-instructions)
+* [Transaction Encoding](#tx-encoding)
 * [Examples](#examples)
     * [Lock value example](#lock-value-example)
     * [Unlock value example](#unlock-value-example)
@@ -1598,7 +1599,17 @@ All unassigned instruction codes are interpreted as no-ops. This are reserved fo
 
 See [Versioning](#versioning).
 
+## Transaction Encoding
 
+This section contains the rules for serializing a [Transaction](#transaction) object.
+
+```
+        SerializedTx = TxHeader || LE32(len(Program)) || Program || Signature || Proof
+        TxHeader = <24 bytes>
+        Program = <len(Program) bytes>
+        Signature = <64 bytes>
+        Proof = <14 * 32 + len(InnerProductProof) bytes>
+```
 
 ## Examples
 

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -1601,7 +1601,7 @@ See [Versioning](#versioning).
 
 ## Transaction Encoding
 
-This section contains the rules for serializing a [Transaction](#transaction) object.
+A [Transaction](#transaction) is serialized as follows:
 
 ```
         SerializedTx = TxHeader || LE32(len(Program)) || Program || Signature || Proof

--- a/zkvm/src/encoding.rs
+++ b/zkvm/src/encoding.rs
@@ -15,7 +15,7 @@ pub struct SliceReader<'a> {
 }
 
 impl<'a> SliceReader<'a> {
-    pub fn new(data: &'a [u8]) -> Self {
+    fn new(data: &'a [u8]) -> Self {
         SliceReader {
             start: 0,
             end: data.len(),

--- a/zkvm/src/encoding.rs
+++ b/zkvm/src/encoding.rs
@@ -15,7 +15,7 @@ pub struct SliceReader<'a> {
 }
 
 impl<'a> SliceReader<'a> {
-    fn new(data: &'a [u8]) -> Self {
+    pub fn new(data: &'a [u8]) -> Self {
         SliceReader {
             start: 0,
             end: data.len(),

--- a/zkvm/src/encoding.rs
+++ b/zkvm/src/encoding.rs
@@ -77,6 +77,12 @@ impl<'a> SliceReader<'a> {
         Ok(x)
     }
 
+    pub fn read_u64(&mut self) -> Result<u64, VMError> {
+        let bytes = self.read_bytes(8)?;
+        let x = LittleEndian::read_u64(&bytes);
+        Ok(x)
+    }
+
     // returns a 32-byte "size" type used in ZkVM
     pub fn read_size(&mut self) -> Result<usize, VMError> {
         let n = self.read_u32()?;
@@ -121,6 +127,18 @@ pub(crate) fn write_u32<'a>(x: u32, target: &mut Vec<u8>) {
     let mut buf = [0u8; 4];
     LittleEndian::write_u32(&mut buf, x);
     target.extend_from_slice(&buf);
+}
+
+// Writes a LE64-encoded integer
+pub(crate) fn write_u64<'a>(x: u64, target: &mut Vec<u8>) {
+    let mut buf = [0u8; 8];
+    LittleEndian::write_u64(&mut buf, x);
+    target.extend_from_slice(&buf);
+}
+
+// Writes a usize as a LE32-encoded integer
+pub(crate) fn write_size<'a>(x: usize, target: &mut Vec<u8>) {
+    write_u32(x as u32, target);
 }
 
 /// Writes a 32-byte array and returns the subsequent slice

--- a/zkvm/src/lib.rs
+++ b/zkvm/src/lib.rs
@@ -3,6 +3,7 @@
 
 #[macro_use]
 extern crate failure;
+extern crate serde;
 
 mod constraints;
 mod contract;

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -19,8 +19,6 @@ use crate::ops::Instruction;
 use crate::point_ops::PointOp;
 use crate::predicate::Predicate;
 use crate::scalar_witness::ScalarWitness;
-// use crate::serde::de::Visitor;
-// use crate::serde::{self, Deserialize, Deserializer, Serialize, Serializer};
 use crate::signature::*;
 use crate::txlog::{Entry, TxID, TxLog};
 use crate::types::*;
@@ -45,7 +43,7 @@ impl TxHeader {
     fn serialized_size(&self) -> usize {
         8 * 3
     }
-    
+
     fn encode(&self, buf: &mut Vec<u8>) {
         encoding::write_u64(self.version, buf);
         encoding::write_u64(self.mintime, buf);

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -83,7 +83,7 @@ impl Tx {
         buf.extend_from_slice(&self.proof.to_bytes());
     }
 
-    fn decode<'a>(r : &mut SliceReader<'a>) -> Result<Tx, VMError> {
+    fn decode<'a>(r: &mut SliceReader<'a>) -> Result<Tx, VMError> {
         let header = TxHeader::decode(r)?;
         let prog_len = r.read_size()?;
         let program = r.read_bytes(prog_len)?.to_vec();


### PR DESCRIPTION
Implements serialization of Tx object. Closes #131 .