### PR TITLE
zkvm/constraints: adds boolean `not` instruction

### DIFF
--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -977,9 +977,9 @@ Code | Instruction                | Stack diagram                              |
 0x0e | [`range:n`](#range)        |            _expr_ → _expr_                 | Modifies [CS](#constraint-system)
 0x0f | [`and`](#and)              | _constr1 constr2_ → _constr3_              |
 0x10 | [`or`](#or)                | _constr1 constr2_ → _constr3_              |
-0x11 | [`not`](#not)              | _constr1_ → _constr2_                      | Modifies [CS](#constraint-system)
+0x11 | [`not`](#not)              |         _constr1_ → _constr2_              | Modifies [CS](#constraint-system)
 0x12 | [`verify`](#verify)        |      _constraint_ → ø                      | Modifies [CS](#constraint-system) 
-0x13 | [`unblind`](#unblind)      |        _V v_ → _V_                         | [Defers point ops](#deferred-point-operations)
+0x13 | [`unblind`](#unblind)      |             _V v_ → _V_                    | [Defers point ops](#deferred-point-operations)
  |                                |                                            |
  |     [**Values**](#value-instructions)              |                        |
 0x14 | [`issue`](#issue)          |    _qty flv data pred_ → _contract_        | Modifies [CS](#constraint-system), [tx log](#transaction-log), [defers point ops](#deferred-point-operations)

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -1213,7 +1213,7 @@ _constr1_ **not** → _constr2_
    x * y = 0
    x * w = 1-y
    ```
-   where `w` is a free variable and `x` is the expression from constraint `c1`.
+   where `w` is a free variable and `x` is the evaluation of constraint `c1`.
 3. Wrap the output `y` in a constraint `c2`.
 4. Push `c2` to the stack.
 

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -1213,7 +1213,7 @@ _constr1_ **not** → _constr2_
    x * y = 0
    x * w = 1-y
    ```
-   where `w` is a random challenge and `x` is the expression from constraint `c1`.
+   where `w` is a free variable and `x` is the expression from constraint `c1`.
 3. Wrap the output `y` in a constraint `c2`.
 4. Push `c2` to the stack.
 

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -977,7 +977,7 @@ Code | Instruction                | Stack diagram                              |
 0x0e | [`range:n`](#range)        |            _expr_ → _expr_                 | Modifies [CS](#constraint-system)
 0x0f | [`and`](#and)              | _constr1 constr2_ → _constr3_              |
 0x10 | [`or`](#or)                | _constr1 constr2_ → _constr3_              |
-0x11 | ['not'](#not)              | _constr1_ → _constr2_                      | Modifies [CS](#constraint-system)
+0x11 | [`not`](#not)              | _constr1_ → _constr2_                      | Modifies [CS](#constraint-system)
 0x12 | [`verify`](#verify)        |      _constraint_ → ø                      | Modifies [CS](#constraint-system) 
 0x13 | [`unblind`](#unblind)      |        _V v_ → _V_                         | [Defers point ops](#deferred-point-operations)
  |                                |                                            |

--- a/zkvm/src/constraints.rs
+++ b/zkvm/src/constraints.rs
@@ -99,8 +99,8 @@ impl Constraint {
         match self {
             Constraint::Eq(expr1, expr2) => {
                 let lc = expr1.to_r1cs_lc() - expr2.to_r1cs_lc();
-                match (expr1.to_scalar(), expr2.to_scalar()) {
-                    (Some(x), Some(y)) => Ok((lc, Some(x - y))),
+                match (expr1.eval(), expr2.eval()) {
+                    (Some(x), Some(y)) => Ok((lc, Some(x.to_scalar() - y.to_scalar()))),
                     (_, _) => Ok((lc, None)),
                 }
             }
@@ -291,11 +291,11 @@ impl Expression {
         }
     }
 
-    fn to_scalar(&self) -> Option<Scalar> {
+    fn eval(&self) -> Option<ScalarWitness> {
         match self {
-            Expression::Constant(a) => Some(a.to_scalar()),
+            Expression::Constant(a) => Some(*a),
             Expression::LinearCombination(_, a) => match a {
-                Some(a) => Some(a.to_scalar()),
+                Some(a) => Some(*a),
                 None => None,
             },
         }

--- a/zkvm/src/constraints.rs
+++ b/zkvm/src/constraints.rs
@@ -133,7 +133,7 @@ impl Constraint {
                         );
                         let w = Scalar::conditional_select(&x, &Scalar::one(), is_zero.into());
                         let w = w.invert();
-                        (Some((x, w)), Some((x, w)), Some(y))
+                        (Some((x, y)), Some((x, w)), Some(y))
                     }
                     None => (None, None, None),
                 };

--- a/zkvm/src/constraints.rs
+++ b/zkvm/src/constraints.rs
@@ -139,7 +139,7 @@ impl Constraint {
                 let (l1, r1, o1) = cs.allocate_multiplier(xy_assg)?;
                 let (_l2, _r2, o2) = cs.allocate_multiplier(xw_assg)?;
 
-                // Add constraints: r2 left unconstrained since w is 
+                // Add constraints: r2 left unconstrained since w is
                 // a free varaible
 
                 // `l1 == x`

--- a/zkvm/src/constraints.rs
+++ b/zkvm/src/constraints.rs
@@ -142,9 +142,12 @@ impl Constraint {
                     None => (None, None, None),
                 };
                 let (x, y, o) = cs.allocate_multiplier(xy)?;
-                cs.constrain(o.into());
+                // constraint x to c1
                 cs.constrain(x - x_lc);
+                // enforce x*y == 0
+                cs.constrain(o.into());
                 let (_x, _w, xw) = cs.allocate_multiplier(xw)?;
+                // enforce x*w = 1 - y
                 cs.constrain(xw - Scalar::one() + y);
                 Ok((r1cs::LinearCombination::from(y), y_assg))
             }

--- a/zkvm/src/ops.rs
+++ b/zkvm/src/ops.rs
@@ -37,6 +37,7 @@ pub enum Instruction {
     Range(BitRange), // bitwidth (0...64)
     And,
     Or,
+    Not,
     Verify,
     Unblind,
     Issue,
@@ -80,27 +81,28 @@ pub enum Opcode {
     Range = 0x0e,
     And = 0x0f,
     Or = 0x10,
-    Verify = 0x11,
-    Unblind = 0x12,
-    Issue = 0x13,
-    Borrow = 0x14,
-    Retire = 0x15,
-    Cloak = 0x16,
-    Import = 0x17,
-    Export = 0x18,
-    Input = 0x19,
-    Output = 0x1a,
-    Contract = 0x1b,
-    Nonce = 0x1c,
-    Log = 0x1d,
-    Signtx = 0x1e,
-    Call = 0x1f,
-    Left = 0x20,
-    Right = 0x21,
+    Not = 0x11,
+    Verify = 0x12,
+    Unblind = 0x13,
+    Issue = 0x14,
+    Borrow = 0x15,
+    Retire = 0x16,
+    Cloak = 0x17,
+    Import = 0x18,
+    Export = 0x19,
+    Input = 0x1a,
+    Output = 0x1b,
+    Contract = 0x1c,
+    Nonce = 0x1d,
+    Log = 0x1e,
+    Signtx = 0x1f,
+    Call = 0x20,
+    Left = 0x21,
+    Right = 0x22,
     Delegate = MAX_OPCODE,
 }
 
-const MAX_OPCODE: u8 = 0x22;
+const MAX_OPCODE: u8 = 0x23;
 
 impl Opcode {
     /// Converts the opcode to `u8`.
@@ -184,6 +186,7 @@ impl Instruction {
             }
             Opcode::And => Ok(Instruction::And),
             Opcode::Or => Ok(Instruction::Or),
+            Opcode::Not => Ok(Instruction::Not),
             Opcode::Verify => Ok(Instruction::Verify),
             Opcode::Unblind => Ok(Instruction::Unblind),
             Opcode::Issue => Ok(Instruction::Issue),
@@ -251,6 +254,7 @@ impl Instruction {
             }
             Instruction::And => write(Opcode::And),
             Instruction::Or => write(Opcode::Or),
+            Instruction::Not => write(Opcode::Not),
             Instruction::Verify => write(Opcode::Verify),
             Instruction::Unblind => write(Opcode::Unblind),
             Instruction::Issue => write(Opcode::Issue),

--- a/zkvm/src/scalar_witness.rs
+++ b/zkvm/src/scalar_witness.rs
@@ -5,7 +5,7 @@ use spacesuit::SignedInteger;
 
 use crate::encoding;
 use crate::errors::VMError;
-use std::ops::{Add, Mul, Neg};
+use std::ops::{Add, Mul, Neg, Sub};
 use std::u64;
 
 /// Represents a concrete kind of a number represented by a scalar.
@@ -78,6 +78,14 @@ impl Add for ScalarWitness {
             },
             (a, b) => ScalarWitness::Scalar(a.to_scalar() + b.to_scalar()),
         }
+    }
+}
+
+impl Sub for ScalarWitness {
+    type Output = ScalarWitness;
+
+    fn sub(self, rhs: ScalarWitness) -> ScalarWitness {
+        -self + rhs
     }
 }
 

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -302,6 +302,7 @@ where
                 Instruction::Range(i) => self.range(i)?,
                 Instruction::And => self.and()?,
                 Instruction::Or => self.or()?,
+                Instruction::Not => self.not()?,
                 Instruction::Verify => self.verify()?,
                 Instruction::Unblind => self.unblind()?,
                 Instruction::Issue => self.issue()?,
@@ -426,6 +427,13 @@ where
         let c1 = self.pop_item()?.to_constraint()?;
         let c3 = Constraint::Or(Box::new(c1), Box::new(c2));
         self.push_item(c3);
+        Ok(())
+    }
+
+    fn not(&mut self) -> Result<(), VMError> {
+        let c1 = self.pop_item()?.to_constraint()?;
+        let c2 = Constraint::Not(Box::new(c1));
+        self.push_item(c2);
         Ok(())
     }
 


### PR DESCRIPTION
Adds boolean `not` instruction. Modifies `Constraint.flatten` to also return an optional assignment, used to calculate the inputs for `not`.

Fixes #117 