### PR TITLE
keytree: store precomputed transcripts on Xprv, Xpub

### DIFF
--- a/keytree/keytree.md
+++ b/keytree/keytree.md
@@ -77,7 +77,7 @@ If you need to share an individual public key, use [leaf key derivation](#derive
 	xprv = Xprv { scalar, dk }
 	```
 5. Create Merlin `t = Transcript::new("Keytree.derivation")`.
-5. Return the resulting extended private key `xprv`.
+6. Return the resulting extended private key `xprv`.
 
 ### Convert Xprv to Xpub
 

--- a/keytree/keytree.md
+++ b/keytree/keytree.md
@@ -43,19 +43,17 @@ Stands for _extended private key_: consists of a secret [scalar](#scalar) and a 
 struct Xprv {
   scalar: Scalar,
   dk: [u8; 32],
-  transcript: Transcript,
 }
 ```
 
 ### Xpub
 
-Stands for _extended public key_: consists of a [point](#point), a [derivation key](#derivation-key), and a transcript.
+Stands for _extended public key_: consists of a [point](#point) and a [derivation key](#derivation-key).
 
 ```rust
 struct Xpub {
-  point: CompressedRistretto,
+  point: RistrettoPoint,
   dk: [u8; 32],
-  Transcript: transcript,
 }
 ```
 
@@ -76,8 +74,8 @@ If you need to share an individual public key, use [leaf key derivation](#derive
 	```
 	xprv = Xprv { scalar, dk }
 	```
-5. Create Merlin `t = Transcript::new("Keytree.derivation")`.
-6. Return the resulting extended private key `xprv`.
+
+5. Return the resulting extended private key `xprv`.
 
 ### Convert Xprv to Xpub
 
@@ -92,29 +90,33 @@ Xpub {
 
 ### Derive an intermediate key
 
-1. Commit [xpub](#xpub) to the provided key's transcript (if xprv is provided, compute xpub from xprv):
+This applies to both Xpubs and Xprvs.
+
+1. Create a Merlin transcript `t = Transcript::new("Keytree.derivation")`.
+2. If you are deriving from a parent Xprv, [create its corresponding parent Xpub first](#convert-xprv-to-xpub).
+3. Commit [xpub](#xpub) to the transcript:
 	```
 	t.commit_bytes("pt", xpub.point)
 	t.commit_bytes("dk", xpub.dk)
 	```
-2. Provide the transcript to the user to commit an arbitrary derivation path or index:
+4. Provide the transcript to the user to commit an arbitrary derivation path or index:
 	```
 	t.commit_bytes(label, data)
 	```
 	E.g. `t.commit_u64("account", account_id)` for an account within a hierarchy of keys.
-3. Squeeze a blinding factor `f`:
+5. Squeeze a blinding factor `f`:
 	```
 	f = t.challenge_scalar("f.intermediate")
 	```
-4. Squeeze a new derivation key `dk2` (32 bytes):
+6. Squeeze a new derivation key `dk2` (32 bytes):
 	```
 	dk2 = t.challenge_bytes("dk")
 	```
-5. For `xprv` (if provided):
+7. If you are deriving a child Xprv from a parent Xprv:
 	```
 	child = Xprv { scalar: parent.scalar + f, dk: dk2 }
 	```
-6. For `xpub`:
+	 If you are deriving a child Xpub from a parent Xpub:
 	```
 	child = Xpub { point: parent.point + f·B, dk: dk2 }
 	```
@@ -123,25 +125,27 @@ Xpub {
 
 Similar to the intermediate derivation, but for safety is domain-separated so the same index produces unrelated public key.
 
-1. Commit [xpub](#xpub) to the provided key's transcript (if xprv is provided, compute xpub from xprv):
+1. Create a Merlin transcript `t = Transcript::new("Keytree.derivation")`.
+2. If you are deriving from a parent Xprv, [create its corresponding parent Xpub first](#convert-xprv-to-xpub).
+3. Commit [xpub](#xpub) to the provided key's transcript:
 	```
 	t.commit_bytes("pt", xpub.point)
 	t.commit_bytes("dk", xpub.dk)
 	```
-2. Provide the transcript to the user to commit an arbitrary selector data (could be structured):
+4. Provide the transcript to the user to commit an arbitrary selector data (could be structured):
 	```
 	t.commit_bytes(label, data)
 	```
 	E.g. `t.commit_u64("invoice", invoice_index)` for a receiving address.
-3. Squeeze a blinding factor `f`:
+5. Squeeze a blinding factor `f`:
 	```
 	f = t.challenge_scalar("f.leaf")
 	```
-4. For `xprv` (if provided) returns a blinded scalar:
+6. If you are deriving a child Xprv from a parent Xprv:
 	```
 	child = parent.scalar + f
 	```
-5. For `xpub` returns a blinded public key:
+	 If you are deriving a child Xpub from a parent Xpub:
 	```
 	child = parent.point + f·B
 	```

--- a/keytree/src/lib.rs
+++ b/keytree/src/lib.rs
@@ -1,22 +1,28 @@
 #![deny(missing_docs)]
 //! Implementation of the key tree protocol, a key blinding scheme for deriving hierarchies of public keys.
 
+use crate::transcript::TranscriptProtocol;
+use merlin::Transcript;
 use curve25519_dalek::constants;
 use curve25519_dalek::ristretto::CompressedRistretto;
 use curve25519_dalek::ristretto::RistrettoPoint;
 use curve25519_dalek::scalar::Scalar;
 use rand::{CryptoRng, RngCore};
 
+mod transcript;
+
 /// Xprv represents an extended private key.
 pub struct Xprv {
     scalar: Scalar,
     dk: [u8; 32],
+    transcript: Transcript,
 }
 
 /// Xpub represents an extended public key.
 pub struct Xpub {
     point: RistrettoPoint,
     dk: [u8; 32],
+    transcript: Transcript,
 }
 
 impl Xprv {
@@ -25,7 +31,12 @@ impl Xprv {
         let scalar = Scalar::random(&mut rng);
         let mut dk = [0u8; 32];
         rng.fill_bytes(&mut dk);
-        Xprv { scalar, dk }
+
+        let mut transcript = Transcript::new(b"Keytree.intermediate");
+        transcript.commit_point(b"pt", &(scalar*&constants::RISTRETTO_BASEPOINT_POINT).compress());
+        transcript.commit_bytes(b"dk", &dk);
+
+        Xprv { scalar, dk, transcript }
     }
 
     /// Returns a new Xpub, generated from the provided Xprv.
@@ -34,6 +45,7 @@ impl Xprv {
         Xpub {
             point: point,
             dk: self.dk,
+            transcript: self.transcript.clone(),
         }
     }
 }

--- a/keytree/src/lib.rs
+++ b/keytree/src/lib.rs
@@ -32,7 +32,7 @@ impl Xprv {
         let mut dk = [0u8; 32];
         rng.fill_bytes(&mut dk);
 
-        let mut transcript = Transcript::new(b"Keytree.intermediate");
+        let mut transcript = Transcript::new(b"Keytree.derivation");
         transcript.commit_point(
             b"pt",
             &(scalar * &constants::RISTRETTO_BASEPOINT_POINT).compress(),

--- a/keytree/src/lib.rs
+++ b/keytree/src/lib.rs
@@ -2,11 +2,11 @@
 //! Implementation of the key tree protocol, a key blinding scheme for deriving hierarchies of public keys.
 
 use crate::transcript::TranscriptProtocol;
-use merlin::Transcript;
 use curve25519_dalek::constants;
 use curve25519_dalek::ristretto::CompressedRistretto;
 use curve25519_dalek::ristretto::RistrettoPoint;
 use curve25519_dalek::scalar::Scalar;
+use merlin::Transcript;
 use rand::{CryptoRng, RngCore};
 
 mod transcript;
@@ -33,10 +33,17 @@ impl Xprv {
         rng.fill_bytes(&mut dk);
 
         let mut transcript = Transcript::new(b"Keytree.intermediate");
-        transcript.commit_point(b"pt", &(scalar*&constants::RISTRETTO_BASEPOINT_POINT).compress());
+        transcript.commit_point(
+            b"pt",
+            &(scalar * &constants::RISTRETTO_BASEPOINT_POINT).compress(),
+        );
         transcript.commit_bytes(b"dk", &dk);
 
-        Xprv { scalar, dk, transcript }
+        Xprv {
+            scalar,
+            dk,
+            transcript,
+        }
     }
 
     /// Returns a new Xpub, generated from the provided Xprv.


### PR DESCRIPTION
This is Step 4 in https://github.com/interstellar/slingshot/pull/202#discussion_r263216987, 
working to make sure that intermediate key derivation isn't failable. 
This PR also updates the spec to match this change.