### PR TITLE
slidechain: display whole response body with friendbot failure

### DIFF
--- a/slidechain/custodian.go
+++ b/slidechain/custodian.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"strings"
@@ -153,7 +154,11 @@ func makeNewCustodianAccount(ctx context.Context, db *sql.DB, hclient horizon.Cl
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, "", fmt.Errorf("bad status code %d funding address through friendbot", resp.StatusCode)
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, "", errors.Wrapf(err, "reading response from bad friendbot request %d", resp.StatusCode)
+		}
+		return nil, "", fmt.Errorf("error funding address through friendbot. got bad status code %d, response %s", resp.StatusCode, body)
 	}
 	log.Println("account successfully funded")
 

--- a/slidechain/stellar/account.go
+++ b/slidechain/stellar/account.go
@@ -2,6 +2,7 @@ package stellar
 
 import (
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 
@@ -35,7 +36,11 @@ func FundAccount(address string) error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("got bad status code %d requesting friendbot lumens", resp.StatusCode)
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return errors.Wrapf(err, "reading response from bad friendbot request %d", resp.StatusCode)
+		}
+		return fmt.Errorf("error funding address through friendbot. got bad status code %d, response %s", resp.StatusCode, body)
 	}
 	return nil
 }


### PR DESCRIPTION
Adds additional logging to display the friendbot response on failure (which includes the transaction XDR and failure codes, helpful for debugging)

New failure log:

```
slidechain_test.go:662: error funding address through friendbot. got bad status code 400, response {
          "type": "https://stellar.org/horizon-errors/https://stellar.org/horizon-errors/transaction_failed",
          "title": "Transaction Failed",
          "status": 400,
          "detail": "The transaction failed when submitted to the stellar network. The `extras.result_codes` field on this response contains further details.  Descriptions of each code can be found at: https://www.stellar.org/developers/learn/concepts/list-of-operations.html",
          "extras": {
            "envelope_xdr": "AAAAABB90WssODNIgi6BHveqzxTRmIpvAFRyVNM+Hm2GVuCcAAAAZAAABD0AAb+mAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAbjzbCARQv30Ik5xJun8fICV05upOXPy7dEt5Nl0Jq+sAAAAXSHboAAAAAAAAAAABhlbgnAAAAEBrpVHoM7sDi5tY9c6Br0tF8ka9QgGz68Pb4TLXKo3LkmouCcyAi5d2/H7EqLgenvfGLQG3IKSj0/pnvW6ovScF",
            "result_codes": {
              "transaction": "tx_failed",
              "operations": [
                "op_already_exists"
              ]
            },
            "result_xdr": "AAAAAAAAAGT/////AAAAAQAAAAAAAAAA/////AAAAAA="
          }
        }
```