### PR TITLE
zkvm: encapsulate bulletproofs dependencies

### DIFF
--- a/zkvm/src/prover.rs
+++ b/zkvm/src/prover.rs
@@ -82,7 +82,7 @@ impl<'a, 'b> Prover<'a, 'b> {
     {
         // Prepare the constraint system
         let mut r1cs_transcript = Transcript::new(b"ZkVM.r1cs");
-        let bp_gens = BulletproofGens::new(128, 1);
+        let bp_gens = BulletproofGens::new(256, 1);
         let pc_gens = PedersenGens::default();
         let cs = r1cs::Prover::new(&bp_gens, &pc_gens, &mut r1cs_transcript);
 

--- a/zkvm/src/prover.rs
+++ b/zkvm/src/prover.rs
@@ -82,7 +82,7 @@ impl<'a, 'b> Prover<'a, 'b> {
     {
         // Prepare the constraint system
         let mut r1cs_transcript = Transcript::new(b"ZkVM.r1cs");
-        let bp_gens = BulletproofGens::new(256, 1);
+        let bp_gens = BulletproofGens::new(128, 1);
         let pc_gens = PedersenGens::default();
         let cs = r1cs::Prover::new(&bp_gens, &pc_gens, &mut r1cs_transcript);
 

--- a/zkvm/src/prover.rs
+++ b/zkvm/src/prover.rs
@@ -72,10 +72,9 @@ impl<'a, 'b> Prover<'a, 'b> {
     /// Builds a transaction with a given list of instructions and a `TxHeader`.
     /// Returns a transaction `Tx` along with its ID (`TxID`) and a transaction log (`TxLog`).
     /// Fails if the input program is malformed, or some witness data is missing.
-    pub fn build_tx<'g, F>(
+    pub fn build_tx<F>(
         program: Program,
         header: TxHeader,
-        bp_gens: &'g BulletproofGens,
         sign_tx_fn: F,
     ) -> Result<(Tx, TxID, TxLog), VMError>
     where
@@ -83,8 +82,9 @@ impl<'a, 'b> Prover<'a, 'b> {
     {
         // Prepare the constraint system
         let mut r1cs_transcript = Transcript::new(b"ZkVM.r1cs");
+        let bp_gens = BulletproofGens::new(256, 1);
         let pc_gens = PedersenGens::default();
-        let cs = r1cs::Prover::new(bp_gens, &pc_gens, &mut r1cs_transcript);
+        let cs = r1cs::Prover::new(&bp_gens, &pc_gens, &mut r1cs_transcript);
 
         // Serialize the tx program
         let mut bytecode = Vec::new();

--- a/zkvm/src/verifier.rs
+++ b/zkvm/src/verifier.rs
@@ -79,10 +79,11 @@ impl<'a, 'b> Delegate<r1cs::Verifier<'a, 'b>> for Verifier<'a, 'b> {
 impl<'a, 'b> Verifier<'a, 'b> {
     /// Verifies the `Tx` object by executing the VM and returns the `VerifiedTx`.
     /// Returns an error if the program is malformed or any of the proofs are not valid.
-    pub fn verify_tx<'g>(tx: Tx, bp_gens: &'g BulletproofGens) -> Result<VerifiedTx, VMError> {
+    pub fn verify_tx<'g>(tx: Tx) -> Result<VerifiedTx, VMError> {
+        let bp_gens = BulletproofGens::new(256, 1);
         let mut r1cs_transcript = Transcript::new(b"ZkVM.r1cs");
         let pc_gens = PedersenGens::default();
-        let cs = r1cs::Verifier::new(bp_gens, &pc_gens, &mut r1cs_transcript);
+        let cs = r1cs::Verifier::new(&bp_gens, &pc_gens, &mut r1cs_transcript);
 
         let mut verifier = Verifier {
             signtx_keys: Vec::new(),

--- a/zkvm/src/verifier.rs
+++ b/zkvm/src/verifier.rs
@@ -79,7 +79,7 @@ impl<'a, 'b> Delegate<r1cs::Verifier<'a, 'b>> for Verifier<'a, 'b> {
 impl<'a, 'b> Verifier<'a, 'b> {
     /// Verifies the `Tx` object by executing the VM and returns the `VerifiedTx`.
     /// Returns an error if the program is malformed or any of the proofs are not valid.
-    pub fn verify_tx<'g>(tx: Tx) -> Result<VerifiedTx, VMError> {
+    pub fn verify_tx(tx: Tx) -> Result<VerifiedTx, VMError> {
         let bp_gens = BulletproofGens::new(256, 1);
         let mut r1cs_transcript = Transcript::new(b"ZkVM.r1cs");
         let pc_gens = PedersenGens::default();

--- a/zkvm/src/verifier.rs
+++ b/zkvm/src/verifier.rs
@@ -80,7 +80,7 @@ impl<'a, 'b> Verifier<'a, 'b> {
     /// Verifies the `Tx` object by executing the VM and returns the `VerifiedTx`.
     /// Returns an error if the program is malformed or any of the proofs are not valid.
     pub fn verify_tx(tx: Tx) -> Result<VerifiedTx, VMError> {
-        let bp_gens = BulletproofGens::new(128, 1);
+        let bp_gens = BulletproofGens::new(256, 1);
         let mut r1cs_transcript = Transcript::new(b"ZkVM.r1cs");
         let pc_gens = PedersenGens::default();
         let cs = r1cs::Verifier::new(&bp_gens, &pc_gens, &mut r1cs_transcript);

--- a/zkvm/src/verifier.rs
+++ b/zkvm/src/verifier.rs
@@ -80,7 +80,7 @@ impl<'a, 'b> Verifier<'a, 'b> {
     /// Verifies the `Tx` object by executing the VM and returns the `VerifiedTx`.
     /// Returns an error if the program is malformed or any of the proofs are not valid.
     pub fn verify_tx(tx: Tx) -> Result<VerifiedTx, VMError> {
-        let bp_gens = BulletproofGens::new(256, 1);
+        let bp_gens = BulletproofGens::new(128, 1);
         let mut r1cs_transcript = Transcript::new(b"ZkVM.r1cs");
         let pc_gens = PedersenGens::default();
         let cs = r1cs::Verifier::new(&bp_gens, &pc_gens, &mut r1cs_transcript);


### PR DESCRIPTION
Fixes #210 - uses capacity of 256 for bulletprooofs generator.