### PR TITLE
zkvm|spacesuit: fix for updated bulletproofs API

### DIFF
--- a/spacesuit/benches/spacesuit.rs
+++ b/spacesuit/benches/spacesuit.rs
@@ -30,13 +30,13 @@ where
     R: rand::RngCore,
 {
     let mut prover_transcript = Transcript::new(b"TransactionTest");
-    let mut prover = Prover::new(&bp_gens, &pc_gens, &mut prover_transcript);
+    let mut prover = Prover::new(&pc_gens, &mut prover_transcript);
 
     let (in_com, in_vars) = inputs.commit(&mut prover, rng);
     let (out_com, out_vars) = outputs.commit(&mut prover, rng);
 
     cloak(&mut prover, in_vars, out_vars)?;
-    let proof = prover.prove()?;
+    let proof = prover.prove(&bp_gens)?;
 
     Ok((proof, in_com, out_com))
 }
@@ -50,14 +50,14 @@ fn verify(
 ) -> Result<(), R1CSError> {
     // Verifier makes a `ConstraintSystem` instance representing a merge gadget
     let mut verifier_transcript = Transcript::new(b"TransactionTest");
-    let mut verifier = Verifier::new(&bp_gens, &pc_gens, &mut verifier_transcript);
+    let mut verifier = Verifier::new(&mut verifier_transcript);
 
     let in_vars = in_com.commit(&mut verifier);
     let out_vars = out_com.commit(&mut verifier);
 
     assert!(cloak(&mut verifier, in_vars, out_vars,).is_ok());
 
-    Ok(verifier.verify(&proof)?)
+    Ok(verifier.verify(&proof, &pc_gens, &bp_gens)?)
 }
 
 fn create_spacesuit_proof_helper(n: usize, c: &mut Criterion) {

--- a/spacesuit/src/range_proof.rs
+++ b/spacesuit/src/range_proof.rs
@@ -81,19 +81,19 @@ mod tests {
             let mut prover_transcript = Transcript::new(b"RangeProofTest");
             let mut rng = rand::thread_rng();
 
-            let mut prover = Prover::new(&bp_gens, &pc_gens, &mut prover_transcript);
+            let mut prover = Prover::new(&pc_gens, &mut prover_transcript);
 
             let (com, var) = prover.commit(v_val.into(), Scalar::random(&mut rng));
             assert!(range_proof(&mut prover, var.into(), Some(v_val), bit_width).is_ok());
 
-            let proof = prover.prove()?;
+            let proof = prover.prove(&bp_gens)?;
 
             (proof, com)
         };
 
         // Verifier makes a `ConstraintSystem` instance representing a merge gadget
         let mut verifier_transcript = Transcript::new(b"RangeProofTest");
-        let mut verifier = Verifier::new(&bp_gens, &pc_gens, &mut verifier_transcript);
+        let mut verifier = Verifier::new(&mut verifier_transcript);
 
         let var = verifier.commit(commitment);
 
@@ -101,6 +101,6 @@ mod tests {
         assert!(range_proof(&mut verifier, var.into(), None, bit_width).is_ok());
 
         // Verifier verifies proof
-        Ok(verifier.verify(&proof)?)
+        Ok(verifier.verify(&proof, &pc_gens, &bp_gens)?)
     }
 }

--- a/spacesuit/src/shuffle.rs
+++ b/spacesuit/src/shuffle.rs
@@ -171,7 +171,7 @@ mod tests {
             let mut prover_transcript = Transcript::new(b"ShuffleTest");
             let mut rng = rand::thread_rng();
 
-            let mut prover = Prover::new(&bp_gens, &pc_gens, &mut prover_transcript);
+            let mut prover = Prover::new(&pc_gens, &mut prover_transcript);
 
             let (input_com, input_vars): (Vec<CompressedRistretto>, Vec<Variable>) = input
                 .iter()
@@ -183,14 +183,14 @@ mod tests {
                 .unzip();
 
             scalar_shuffle(&mut prover, input_vars, output_vars)?;
-            let proof = prover.prove()?;
+            let proof = prover.prove(&bp_gens)?;
 
             (proof, input_com, output_com)
         };
 
         // Verifier makes a `ConstraintSystem` instance representing a shuffle gadget
         let mut verifier_transcript = Transcript::new(b"ShuffleTest");
-        let mut verifier = Verifier::new(&bp_gens, &pc_gens, &mut verifier_transcript);
+        let mut verifier = Verifier::new(&mut verifier_transcript);
 
         let input_vars: Vec<Variable> = input_com.iter().map(|com| verifier.commit(*com)).collect();
         let output_vars: Vec<Variable> =
@@ -199,7 +199,7 @@ mod tests {
         // Verifier adds constraints to the constraint system
         scalar_shuffle(&mut verifier, input_vars, output_vars)?;
 
-        Ok(verifier.verify(&proof)?)
+        Ok(verifier.verify(&proof, &pc_gens, &bp_gens)?)
     }
 
     // Helper functions to make the tests easier to read
@@ -301,19 +301,19 @@ mod tests {
             let mut prover_transcript = Transcript::new(b"ValueShuffleTest");
             let mut rng = rand::thread_rng();
 
-            let mut prover = Prover::new(&bp_gens, &pc_gens, &mut prover_transcript);
+            let mut prover = Prover::new(&pc_gens, &mut prover_transcript);
             let (input_com, input_vars) = input.commit(&mut prover, &mut rng);
             let (output_com, output_vars) = output.commit(&mut prover, &mut rng);
 
             assert!(value_shuffle(&mut prover, input_vars, output_vars).is_ok());
 
-            let proof = prover.prove()?;
+            let proof = prover.prove(&bp_gens)?;
             (proof, input_com, output_com)
         };
 
         // Verifier makes a `ConstraintSystem` instance representing a shuffle gadget
         let mut verifier_transcript = Transcript::new(b"ValueShuffleTest");
-        let mut verifier = Verifier::new(&bp_gens, &pc_gens, &mut verifier_transcript);
+        let mut verifier = Verifier::new(&mut verifier_transcript);
 
         let input_vars = input_com.commit(&mut verifier);
         let output_vars = output_com.commit(&mut verifier);
@@ -322,7 +322,7 @@ mod tests {
         assert!(value_shuffle(&mut verifier, input_vars, output_vars).is_ok());
 
         // Verifier verifies proof
-        Ok(verifier.verify(&proof)?)
+        Ok(verifier.verify(&proof, &pc_gens, &bp_gens)?)
     }
 
     #[test]
@@ -385,19 +385,19 @@ mod tests {
             let mut prover_transcript = Transcript::new(b"PaddedShuffleTest");
             let mut rng = rand::thread_rng();
 
-            let mut prover = Prover::new(&bp_gens, &pc_gens, &mut prover_transcript);
+            let mut prover = Prover::new(&pc_gens, &mut prover_transcript);
             let (input_com, input_vars) = input.commit(&mut prover, &mut rng);
             let (output_com, output_vars) = output.commit(&mut prover, &mut rng);
 
             assert!(padded_shuffle(&mut prover, input_vars, output_vars).is_ok());
 
-            let proof = prover.prove()?;
+            let proof = prover.prove(&bp_gens)?;
             (proof, input_com, output_com)
         };
 
         // Verifier makes a `ConstraintSystem` instance representing a shuffle gadget
         let mut verifier_transcript = Transcript::new(b"PaddedShuffleTest");
-        let mut verifier = Verifier::new(&bp_gens, &pc_gens, &mut verifier_transcript);
+        let mut verifier = Verifier::new(&mut verifier_transcript);
 
         let input_vars = input_com.commit(&mut verifier);
         let output_vars = output_com.commit(&mut verifier);
@@ -406,6 +406,6 @@ mod tests {
         assert!(padded_shuffle(&mut verifier, input_vars, output_vars).is_ok());
 
         // Verifier verifies proof
-        Ok(verifier.verify(&proof)?)
+        Ok(verifier.verify(&proof, &pc_gens, &bp_gens)?)
     }
 }

--- a/spacesuit/tests/spacesuit.rs
+++ b/spacesuit/tests/spacesuit.rs
@@ -34,13 +34,13 @@ where
     R: rand::RngCore,
 {
     let mut prover_transcript = Transcript::new(b"TransactionTest");
-    let mut prover = Prover::new(&bp_gens, &pc_gens, &mut prover_transcript);
+    let mut prover = Prover::new(&pc_gens, &mut prover_transcript);
 
     let (in_com, in_vars) = inputs.commit(&mut prover, rng);
     let (out_com, out_vars) = outputs.commit(&mut prover, rng);
 
     cloak(&mut prover, in_vars, out_vars)?;
-    let proof = prover.prove()?;
+    let proof = prover.prove(&bp_gens)?;
 
     Ok((proof, in_com, out_com))
 }
@@ -54,14 +54,14 @@ fn verify(
 ) -> Result<(), R1CSError> {
     // Verifier makes a `ConstraintSystem` instance representing a merge gadget
     let mut verifier_transcript = Transcript::new(b"TransactionTest");
-    let mut verifier = Verifier::new(&bp_gens, &pc_gens, &mut verifier_transcript);
+    let mut verifier = Verifier::new(&mut verifier_transcript);
 
     let in_vars = in_com.commit(&mut verifier);
     let out_vars = out_com.commit(&mut verifier);
 
     assert!(cloak(&mut verifier, in_vars, out_vars,).is_ok());
 
-    Ok(verifier.verify(&proof)?)
+    Ok(verifier.verify(&proof, &pc_gens, &bp_gens)?)
 }
 
 // Helper functions to make the tests easier to read

--- a/zkvm/src/prover.rs
+++ b/zkvm/src/prover.rs
@@ -18,16 +18,16 @@ use crate::vm::{Delegate, Tx, TxHeader, VM};
 /// Prover passes the list of instructions through the VM,
 /// creates an aggregated transaction signature (for `signtx` instruction),
 /// creates a R1CS proof and returns a complete `Tx` object that can be published.
-pub struct Prover<'a, 'b> {
+pub struct Prover<'t, 'g> {
     signtx_keys: Vec<VerificationKey>,
-    cs: r1cs::Prover<'a, 'b>,
+    cs: r1cs::Prover<'t, 'g>,
 }
 
 pub(crate) struct ProverRun {
     program: VecDeque<Instruction>,
 }
 
-impl<'a, 'b> Delegate<r1cs::Prover<'a, 'b>> for Prover<'a, 'b> {
+impl<'t, 'g> Delegate<r1cs::Prover<'t, 'g>> for Prover<'t, 'g> {
     type RunType = ProverRun;
 
     fn commit_variable(
@@ -64,19 +64,19 @@ impl<'a, 'b> Delegate<r1cs::Prover<'a, 'b>> for Prover<'a, 'b> {
         })
     }
 
-    fn cs(&mut self) -> &mut r1cs::Prover<'a, 'b> {
+    fn cs(&mut self) -> &mut r1cs::Prover<'t, 'g> {
         &mut self.cs
     }
 }
 
-impl<'a, 'b> Prover<'a, 'b> {
+impl<'t, 'g> Prover<'t, 'g> {
     /// Builds a transaction with a given list of instructions and a `TxHeader`.
     /// Returns a transaction `Tx` along with its ID (`TxID`) and a transaction log (`TxLog`).
     /// Fails if the input program is malformed, or some witness data is missing.
-    pub fn build_tx<'g, F>(
+    pub fn build_tx<F>(
         program: Program,
         header: TxHeader,
-        bp_gens: &'g BulletproofGens,
+        bp_gens: &BulletproofGens,
         sign_tx_fn: F,
     ) -> Result<(Tx, TxID, TxLog), VMError>
     where
@@ -85,7 +85,7 @@ impl<'a, 'b> Prover<'a, 'b> {
         // Prepare the constraint system
         let mut r1cs_transcript = Transcript::new(b"ZkVM.r1cs");
         let pc_gens = PedersenGens::default();
-        let cs = r1cs::Prover::new(bp_gens, &pc_gens, &mut r1cs_transcript);
+        let cs = r1cs::Prover::new(&pc_gens, &mut r1cs_transcript);
 
         // Serialize the tx program
         let mut bytecode = Vec::new();
@@ -113,7 +113,10 @@ impl<'a, 'b> Prover<'a, 'b> {
         let signature = sign_tx_fn(&mut signtx_transcript, &prover.signtx_keys);
 
         // Generate the R1CS proof
-        let proof = prover.cs.prove().map_err(|_| VMError::InvalidR1CSProof)?;
+        let proof = prover
+            .cs
+            .prove(bp_gens)
+            .map_err(|_| VMError::InvalidR1CSProof)?;
 
         Ok((
             Tx {

--- a/zkvm/src/verifier.rs
+++ b/zkvm/src/verifier.rs
@@ -18,10 +18,10 @@ use crate::vm::{Delegate, Tx, VerifiedTx, VM};
 /// verifies an aggregated transaction signature (see `signtx` instruction),
 /// verifies a R1CS proof and returns a `VerifiedTx` with the log of changes
 /// to be applied to the blockchain state.
-pub struct Verifier<'a, 'b> {
+pub struct Verifier<'t> {
     signtx_keys: Vec<VerificationKey>,
     deferred_operations: Vec<PointOp>,
-    cs: r1cs::Verifier<'a, 'b>,
+    cs: r1cs::Verifier<'t>,
 }
 
 pub struct VerifierRun {
@@ -29,7 +29,7 @@ pub struct VerifierRun {
     offset: usize,
 }
 
-impl<'a, 'b> Delegate<r1cs::Verifier<'a, 'b>> for Verifier<'a, 'b> {
+impl<'t> Delegate<r1cs::Verifier<'t>> for Verifier<'t> {
     type RunType = VerifierRun;
 
     fn commit_variable(
@@ -71,18 +71,17 @@ impl<'a, 'b> Delegate<r1cs::Verifier<'a, 'b>> for Verifier<'a, 'b> {
         Ok(VerifierRun::new(prog.to_bytes()))
     }
 
-    fn cs(&mut self) -> &mut r1cs::Verifier<'a, 'b> {
+    fn cs(&mut self) -> &mut r1cs::Verifier<'t> {
         &mut self.cs
     }
 }
 
-impl<'a, 'b> Verifier<'a, 'b> {
+impl<'t> Verifier<'t> {
     /// Verifies the `Tx` object by executing the VM and returns the `VerifiedTx`.
     /// Returns an error if the program is malformed or any of the proofs are not valid.
-    pub fn verify_tx<'g>(tx: Tx, bp_gens: &'g BulletproofGens) -> Result<VerifiedTx, VMError> {
+    pub fn verify_tx(tx: Tx, bp_gens: &BulletproofGens) -> Result<VerifiedTx, VMError> {
         let mut r1cs_transcript = Transcript::new(b"ZkVM.r1cs");
-        let pc_gens = PedersenGens::default();
-        let cs = r1cs::Verifier::new(bp_gens, &pc_gens, &mut r1cs_transcript);
+        let cs = r1cs::Verifier::new(&mut r1cs_transcript);
 
         let mut verifier = Verifier {
             signtx_keys: Vec::new(),
@@ -106,9 +105,14 @@ impl<'a, 'b> Verifier<'a, 'b> {
         PointOp::verify_batch(&verifier.deferred_operations[..])?;
 
         // Verify the R1CS proof
+
+        // TBD: provide is as a precomputed object to avoid
+        // creating secondary point per each tx verification
+        let pc_gens = PedersenGens::default();
+
         verifier
             .cs
-            .verify(&tx.proof)
+            .verify(&tx.proof, &pc_gens, bp_gens)
             .map_err(|_| VMError::InvalidR1CSProof)?;
 
         Ok(VerifiedTx {


### PR DESCRIPTION
This tweaks the usage of r1cs::Prover/Verifier to the updated API in the `develop` branch of the Bulletproofs: https://github.com/dalek-cryptography/bulletproofs/pull/257

Folks, run `cargo update` if you have weird compilation errors (after merging this PR).
