### PR TITLE
spacesuit & zkvm: add backrefs to old repos

### DIFF
--- a/spacesuit/README.md
+++ b/spacesuit/README.md
@@ -28,6 +28,9 @@ benchmarks with `cargo bench`.
 This is a research project sponsored by [Interstellar][interstellar],
 developed by Henry de Valence, Cathie Yun, and Oleg Andreev.
 
+The Spacesuit repository was moved from [this location][old_repo] on 2/7/2019.
+
+
 [bp_website]: https://crypto.stanford.edu/bulletproofs/
 [bp_repo]: https://github.com/dalek-cryptography/bulletproofs/
 [interstellar]: https://interstellar.com/
@@ -35,3 +38,4 @@ developed by Henry de Valence, Cathie Yun, and Oleg Andreev.
 [spacesuit_repo]: https://github.com/interstellar/slingshot/blob/main/spacesuit
 [spacesuit_crate]: https://crates.io/crates/spacesuit
 [criterion]: https://github.com/japaric/criterion.rs
+[old_repo]: https://github.com/interstellar/spacesuit

--- a/zkvm/README.md
+++ b/zkvm/README.md
@@ -44,3 +44,5 @@ All instructions that perform relatively expensive scalar-point multiplications 
 * [Ristretto group](https://ristretto.group)
 * [Bulletproofs R1CS](https://doc-internal.dalek.rs/develop/bulletproofs/notes/r1cs_proof/index.html)
 * [Cloak](../spacesuit/spec.md)
+
+The ZkVM repository was moved from [this location](https://github.com/interstellar/zkvm) on 2/6/2019.


### PR DESCRIPTION
Add links to the old spacesuit and zkvm repos, for the sake of continuity and ability to reference old commits and issues. 