### PR TITLE
zkvm/key: use MuSig key aggregation scheme

### DIFF
--- a/token/src/token.rs
+++ b/token/src/token.rs
@@ -97,7 +97,7 @@ mod tests {
 
         // Verify tx
         let bp_gens = BulletproofGens::new(256, 1);
-        assert!(Verifier::verify_tx(tx, &bp_gens, |keys| keys::aggregated_pubkey(keys)).is_ok());
+        assert!(Verifier::verify_tx(tx, &bp_gens).is_ok());
     }
 
     #[test]
@@ -129,7 +129,7 @@ mod tests {
 
         // Verify tx
         let bp_gens = BulletproofGens::new(256, 1);
-        assert!(Verifier::verify_tx(tx, &bp_gens, |keys| keys::aggregated_pubkey(keys)).is_ok());
+        assert!(Verifier::verify_tx(tx, &bp_gens).is_ok());
     }
 
     // Helper functions
@@ -156,7 +156,7 @@ mod tests {
                 .collect();
             Ok(Signature::sign_single(
                 &mut t.clone(),
-                keys::aggregated_privkey(&signtx_keys),
+                keys::aggregated_privkey(&signtx_keys)?,
             ))
         })
     }

--- a/zkvm/src/keys.rs
+++ b/zkvm/src/keys.rs
@@ -8,8 +8,8 @@ use crate::errors::VMError;
 use crate::transcript::TranscriptProtocol;
 
 /// Creates an aggregated Schnorr private key for signing from
-/// a single party's set of private keys. 
-/// Mirrors the MuSig multi-party aggregation scheme so that 
+/// a single party's set of private keys.
+/// Mirrors the MuSig multi-party aggregation scheme so that
 /// aggregated pubkeys are consistent across both methods.
 pub fn aggregated_privkey(privkeys: &[Scalar]) -> Result<Scalar, VMError> {
     match privkeys.len() {

--- a/zkvm/src/keys.rs
+++ b/zkvm/src/keys.rs
@@ -8,7 +8,9 @@ use crate::errors::VMError;
 use crate::transcript::TranscriptProtocol;
 
 /// Creates an aggregated Schnorr private key for signing from
-/// a single party's set of private keys.
+/// a single party's set of private keys. 
+/// Mirrors the MuSig multi-party aggregation scheme so that 
+/// aggregated pubkeys are consistent across both methods.
 pub fn aggregated_privkey(privkeys: &[Scalar]) -> Result<Scalar, VMError> {
     match privkeys.len() {
         0 => {
@@ -20,6 +22,7 @@ pub fn aggregated_privkey(privkeys: &[Scalar]) -> Result<Scalar, VMError> {
         _ => {}
     }
 
+    // Initialize transcript to match Musig aggregation scheme.
     let mut transcript = Transcript::new(b"Musig.aggregated-key");
     // Derive public keys from privkeys
     let pubkeys = privkeys

--- a/zkvm/src/verifier.rs
+++ b/zkvm/src/verifier.rs
@@ -99,7 +99,8 @@ impl<'t> Verifier<'t> {
 
         if verifier.signtx_keys.len() != 0 {
             verifier.deferred_operations.push(
-                // TODO: change this to use multi-message context
+                /// TODO: use MuSig multi-message API, signing contract
+                /// IDs in addition to TxID for each key.
                 tx.signature
                     .verify(
                         &mut signtx_transcript,

--- a/zkvm/src/verifier.rs
+++ b/zkvm/src/verifier.rs
@@ -2,7 +2,7 @@ use bulletproofs::r1cs;
 use bulletproofs::{BulletproofGens, PedersenGens};
 use curve25519_dalek::ristretto::CompressedRistretto;
 use merlin::Transcript;
-use musig::VerificationKey;
+use musig::{Multikey, VerificationKey};
 
 use crate::constraints::Commitment;
 use crate::encoding::*;
@@ -79,14 +79,7 @@ impl<'t> Delegate<r1cs::Verifier<'t>> for Verifier<'t> {
 impl<'t> Verifier<'t> {
     /// Verifies the `Tx` object by executing the VM and returns the `VerifiedTx`.
     /// Returns an error if the program is malformed or any of the proofs are not valid.
-    pub fn verify_tx<F>(
-        tx: Tx,
-        bp_gens: &BulletproofGens,
-        key_agg_fn: F,
-    ) -> Result<VerifiedTx, VMError>
-    where
-        F: FnOnce(&[VerificationKey]) -> Result<VerificationKey, VMError>,
-    {
+    pub fn verify_tx(tx: Tx, bp_gens: &BulletproofGens) -> Result<VerifiedTx, VMError> {
         let mut r1cs_transcript = Transcript::new(b"ZkVM.r1cs");
         let cs = r1cs::Verifier::new(&mut r1cs_transcript);
 
@@ -108,7 +101,12 @@ impl<'t> Verifier<'t> {
             verifier.deferred_operations.push(
                 // TODO: change this to use multi-message context
                 tx.signature
-                    .verify(&mut signtx_transcript, key_agg_fn(&verifier.signtx_keys)?)
+                    .verify(
+                        &mut signtx_transcript,
+                        Multikey::new(verifier.signtx_keys)
+                            .map_err(|_| VMError::KeyAggregationFailed)?
+                            .aggregated_key(),
+                    )
                     .into(),
             );
         }

--- a/zkvm/tests/zkvm.rs
+++ b/zkvm/tests/zkvm.rs
@@ -164,7 +164,7 @@ fn build_and_verify(program: Program, keys: &Vec<Scalar>) -> Result<TxID, VMErro
                 .collect();
             Ok(Signature::sign_single(
                 &mut t.clone(),
-                keys::aggregated_privkey(&signtx_keys),
+                keys::aggregated_privkey(&signtx_keys)?,
             ))
         })?
     };
@@ -172,7 +172,7 @@ fn build_and_verify(program: Program, keys: &Vec<Scalar>) -> Result<TxID, VMErro
     // Verify tx
     let bp_gens = BulletproofGens::new(256, 1);
 
-    let vtx = Verifier::verify_tx(tx, &bp_gens, |keys| keys::aggregated_pubkey(keys))?;
+    let vtx = Verifier::verify_tx(tx, &bp_gens)?;
     Ok(vtx.id)
 }
 


### PR DESCRIPTION
Removes the `key_agg_fn` closure in `Verifier::verify_tx` to make key aggregation consistent between Multikey and single-party Schnorr aggregation. 

Sparked by [this conversation](https://i10r.slack.com/archives/CEMSC5YRK/p1554331172056000) since we want all transactions to be verifiable without this extra per-tx information about which key aggregation scheme to use. 