### PR TITLE
zkvm: remove nonces

### DIFF
--- a/token/src/token.rs
+++ b/token/src/token.rs
@@ -62,18 +62,21 @@ impl Token {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use zkvm::{Anchor, Contract};
+
     use bulletproofs::{BulletproofGens, PedersenGens};
     use zkvm::{
         Entry, Predicate, Program, Prover, Signature, Tx, TxHeader, TxID, TxLog, VMError,
         VerificationKey, Verifier,
     };
 
-    fn add_nonce(p: &mut Program, nonce_key: &Scalar) {
-        let dummy_block_id = Data::Opaque([0xffu8; 32].to_vec());
-        p.push(Predicate::Key(VerificationKey::from_secret(nonce_key)))
-            .push(dummy_block_id)
-            .nonce()
-            .sign_tx();
+    fn add_dummy_input(p: &mut Program, dummy_key: &Scalar) {
+        let contract = Contract {
+            anchor: Anchor::from_raw_bytes([0u8; 32]),
+            payload: vec![],
+            predicate: Predicate::Key(VerificationKey::from_secret(dummy_key)),
+        };
+        p.push(Output::new(contract)).input().sign_tx();
     }
 
     #[test]
@@ -81,7 +84,7 @@ mod tests {
         let (tx, _, _) = {
             let issue_key = Scalar::from(1u64);
             let dest_key = Scalar::from(2u64);
-            let nonce_key = Scalar::from(3u64);
+            let dummy_key = Scalar::from(3u64);
             let usd = Token::new(
                 Predicate::Key(VerificationKey::from_secret(&issue_key)),
                 b"USD".to_vec(),
@@ -89,10 +92,10 @@ mod tests {
             let dest = Predicate::Key(VerificationKey::from_secret(&dest_key));
 
             let program = Program::build(|p| {
-                add_nonce(p, &nonce_key);
+                add_dummy_input(p, &dummy_key);
                 usd.issue_to(p, 10u64, dest.clone())
             });
-            build(program, vec![issue_key, nonce_key]).unwrap()
+            build(program, vec![issue_key, dummy_key]).unwrap()
         };
 
         // Verify tx
@@ -106,17 +109,17 @@ mod tests {
         let (tx, _, _) = {
             let issue_key = Scalar::from(1u64);
             let dest_key = Scalar::from(2u64);
-            let nonce_key = Scalar::from(3u64);
+            let dummy_key = Scalar::from(3u64);
             let usd = Token::new(
                 Predicate::Key(VerificationKey::from_secret(&issue_key)),
                 b"USD".to_vec(),
             );
             let dest = Predicate::Key(VerificationKey::from_secret(&dest_key));
             let issue_program = Program::build(|p| {
-                add_nonce(p, &nonce_key);
+                add_dummy_input(p, &dummy_key);
                 usd.issue_to(p, 10u64, dest.clone())
             });
-            let (_, _, issue_txlog) = build(issue_program, vec![issue_key, nonce_key]).unwrap();
+            let (_, _, issue_txlog) = build(issue_program, vec![issue_key, dummy_key]).unwrap();
 
             let mut retire_program = Program::new();
             let issue_output = match &issue_txlog[3] {

--- a/zkvm/docs/zkvm-blockchain.md
+++ b/zkvm/docs/zkvm-blockchain.md
@@ -35,10 +35,6 @@ The blockchain state contains:
   This never changes.
 - `tipheader`: The latest block header.
 - `utxos`: The set of current [utxo IDs](zkvm-spec.md#utxo).
-- `nonces`: The set of `<anchor,maxtime_ms>` pairs for all current [nonces](zkvm-spec.md#nonce).
-- `refids`: The set of recent [block IDs](#block-id).
-  The size of this set is bounded by `block.header.refscount`.
-  Block IDs in this set may be referenced by nonces.
 
 ## Block
 
@@ -68,10 +64,7 @@ A block header contains:
   00:00:00 UTC Jan 1, 1970.
   Each new block must have a time strictly later than the block before it.
 - `txroot`: 32-byte [Merkle root hash](zkvm-spec.md#merkle-binary-tree) of the transactions in the block.
-- `utxoroot`: 32-byte [Merkle patricia root hash](#merkle-patricia-tree) of the utxo set after applying all transactions in the block.
-- `nonceroot`: 32-byte [Merkle patricia root hash](#merkle-patricia-tree) of the nonce set after applying all transactions in the block.
-- `refscount`: Integer number of recent block IDs to store for reference.
-  A new block may specify a lower `refscount` than its predecessor but may not increase it by more than 1.
+- `utxoroot`: 32-byte [Merkle root hash](zkvm-spec.md#merkle-binary-tree) of the utxo set after applying all transactions in the block.
 - `ext`: Variable-length byte string to contain future extensions.
   Empty in version 1.
 
@@ -87,84 +80,8 @@ T.commit("previd", previd)
 T.commit("timestamp_ms", LE64(timestamp_ms))
 T.commit("txroot", txroot)
 T.commit("utxoroot", utxoroot)
-T.commit("nonceroot", nonceroot)
-T.commit("refscount", LE64(refscount))
 T.commit("ext", ext)
 blockid = T.challenge_bytes("id")
-```
-
-## Merkle patricia tree
-
-A Merkle patricia tree is similar to a [Merkle binary tree](zkvm-spec.md#merkle-binary-tree).
-Its membership uniquely determines its shape.
-Each node hashes the subtrees beneath it.
-The root node’s hash is a commitment to the full membership of the tree.
-It is possible to create and verify compact proofs of membership.
-
-Unlike a Merkle binary tree,
-a Merkle patricia tree is a radix tree
-(in which subtrees of a given node share a common prefix)
-with variable-length branches that allow for efficient updates.
-It is therefore preferable to a Merkle binary tree for large sets with frequent and comparatively small updates,
-specifically the utxo set and the nonce set.
-
-As with the Merkle binary tree,
-we define a Merkle patricia tree in terms of [transcripts](zkvm-spec.md#transcript).
-Leaves and nodes in the tree use the same instance of a transcript:
-
-```
-T = Transcript(<label>)
-```
-
-(where `<label>` is specified by the calling protocol).
-
-The input to the *Merkle patricia tree hash*
-(MPTH)
-is a list of data entries.
-These entries will be hashed to form the leaves of the merkle hash tree.
-The output is a single 32-byte hash value.
-The input list must be prefix-free;
-that is,
-no element can be a prefix of any other.
-Given a sorted list of n unique inputs,
-
-```
-D[n] = {d(0), d(1), ..., d(n-1)}
-```
-
-the MPTH is thus defined as follows.
-
-The hash of an empty Merkle patricia tree list is a 32-byte challenge string with the label `patricia.empty`:
-
-```
-MPTH(T, {}) = T.challenge_bytes("patricia.empty")
-```
-
-To compute the hash of a list with one entry,
-commit it to the transcript with the label `patricia.leaf` and then generate a 32-byte challenge string with the same label:
-
-```
-T.commit("patricia.leaf", d(0))
-MPTH(T, {d{0)}) = T.challenge_bytes("patricia.leaf")
-```
-
-To compute the hash of a list with two or more entries:
-1. Let the bit string `p` be the longest common prefix of all entries;
-2. Let k be the number of items with prefix `p||0`
-   (that is,
-   `p` concatenated with the single bit 0).
-3. Let L be recursively defined as `MPTH(T, D[0:k])`
-   (the hash of the first `k` elements of D).
-4. Commit `L` to `T` with the label `patricia.left`.
-5. Let R be recursively defined as `MPTH(T, D[k:n])`
-   (the hash of the remaining `n-k` elements of D).
-5. Commit `R` to `T` with the label `patricia.right`.
-6. Generate a 32-byte challenge string with the label `patricia.node`.
-
-```
-T.commit("patricia.left", MPTH(T, D[0:k]))
-T.commit("patricia.right", MPTH(T, D[k:n]))
-MPTH(T, D) = T.challenge_bytes("patricia.node")
 ```
 
 
@@ -182,51 +99,42 @@ Its [blockchain state](#blockchain-state) is set to the result of the procedure.
 
 Inputs:
 - `timestamp_ms`,
-  the current time as a number of milliseconds since the Unix epoch:
-  00:00:00 UTC Jan 1,
-  1970.
-- `refscount`,
-  the number of recent block ids to cache for
-  [nonce](zkvm-spec.md#nonce)
-  uniqueness.
+  the current time as a number of milliseconds since the Unix epoch: 00:00:00 UTC Jan 1, 1970.
+- `utxos`,
+  the starting utxo set that allows bootstrapping the anchors.
 
 Output:
 - Blockchain state.
 
 Procedure:
-1. [Make an initial block header](#make-initial-block-header) `initialheader` from `timestamp_ms` and `refscount`.
+1. [Make an initial block header](#make-initial-block-header) `initialheader` from `timestamp_ms` and `utxos`.
 2. Return a blockchain state with its fields set as follows:
    - `initialheader`: `initialheader`
    - `tipheader`: `initialheader`
-   - `utxos`: empty set
-   - `nonces`: empty set
-   - `refids`: empty set
+   - `utxos`: `utxos`
 
 ## Make initial block header
 
 Inputs:
 - `timestamp_ms`,
-  the current time as a number of milliseconds since the Unix epoch:
-  00:00:00 UTC Jan 1, 1970.
-- `refscount`,
-  the number of recent block ids to cache for [nonce](zkvm-spec.md#nonce) uniqueness.
+  the current time as a number of milliseconds since the Unix epoch: 00:00:00 UTC Jan 1, 1970.
+- `utxos`,
+  the initial utxo set that bootstraps [ZkVM anchors](zkvm-spec.md#anchor).
+
 
 Output:
 - A [block header](#block-header).
 
 Procedure:
 1. [Compute txroot](#compute-txroot) from an empty list of transaction ids.
-2. [Compute utxoroot](#compute-utxoroot) from an empty set of utxos.
-3. [Compute nonceroot](#compute-nonceroot) from an empty set of nonce anchors.
-4. Return a block header with its fields set as follows:
+2. [Compute utxoroot](#compute-utxoroot) from a set of `utxos`.
+3. Return a [block header](#block-header) with its fields set as follows:
    - `version`: 1
    - `height`: 1
    - `previd`: all-zero string of 32-bytes
    - `timestamp_ms`: `timestamp_ms`
    - `txroot`: `txroot`
    - `utxoroot`: `utxoroot`
-   - `nonceroot`: `nonceroot`
-   - `refscount`: `refscount`
    - `ext`: empty
 
 ## Join existing network
@@ -267,11 +175,10 @@ Procedure:
 3. Verify `block.header.height == prevheader.height+1`.
 4. Verify `block.header.previd` equals the [block ID](#block-id) of `prevheader`.
 5. Verify `block.header.timestamp_ms > prevheader.timestamp_ms`.
-6. Verify `block.header.refscount >= 0` and `block.header.refscount <= prevheader.refscount + 1`.
-7. Let `txlogs` and `txids` be the result of [executing the transactions in block.txs](#execute-transaction-list) with `block.header.version` and `block.header.timestamp_ms`.
-8. [Compute txroot](#compute-txroot) from `txids`.
-9. Verify `txroot == block.header.txroot`.
-10. Return `txlogs`.
+6. Let `txlogs` and `txids` be the result of [executing the transactions in block.txs](#execute-transaction-list) with `block.header.version` and `block.header.timestamp_ms`.
+7. [Compute txroot](#compute-txroot) from `txids`.
+8. Verify `txroot == block.header.txroot`.
+9. Return `txlogs`.
 
 
 ## Make block
@@ -288,10 +195,6 @@ Inputs:
   00:00:00 UTC Jan 1, 1970.
   This must be strictly greater than `state.tipheader.timestamp_ms`,
   the timestamp of the previous block header.
-- `refscount`,
-  a number of recent block IDs to store for reference.
-  Note that this must lie between 0 and `state.tipheader.refscount+1`,
-  inclusive.
 - `txs`,
   a list of [transactions](zkvm-spec.md#transaction).
 - `ext`,
@@ -311,18 +214,15 @@ Procedure:
    computed from each transaction’s [header entry](zkvm-spec.md#header-entry) and the corresponding item from `txlogs`.
 5. [Compute txroot](#compute-txroot) from `txids` to produce `txroot`.
 6. [Compute utxoroot](#compute-utxoroot) from `state′.utxos` to produce `utxoroot`.
-7. [Compute nonceroot](#compute-nonceroot) from the anchors in `state′.nonces` to produce `nonceroot`.
-8. Let `h` be a [block header](#block-header) with its fields set as follows:
+7. Let `h` be a [block header](#block-header) with its fields set as follows:
    - `version`: `version`
    - `height`: `state.tipheader.height+1`
    - `previd`: `previd`
    - `timestamp_ms`: `timestamp_ms`
    - `txroot`: `txroot`
    - `utxoroot`: `utxoroot`
-   - `nonceroot`: `nonceroot`
-   - `refscount`: `refscount`
    - `ext`: `ext`
-9. Return a block with header `h` and transactions `txs`.
+8. Return a block with header `h` and transactions `txs`.
 
 
 ## Execute transaction list
@@ -347,8 +247,7 @@ Procedure:
    Let `txids` be an empty list of transaction IDs.
 2. For each transaction `tx` in `txs`:
    1. Verify `tx.mintime_ms <= timestamp_ms <= tx.maxtime_ms`.
-   2. If `version == 1`,
-      verify `tx.version == 1`.
+   2. If `version == 1`, verify `tx.version == 1`.
    3. [Execute](zkvm-spec.md#vm-execution) `tx` to produce transaction log `txlog`.
    4. Add `txlog` to `txlogs`.
    5. Compute transaction ID `txid` from the [header entry](zkvm-spec.md#header-entry) of `tx` and from `txlog`.
@@ -374,17 +273,12 @@ Output:
 Procedure:
 1. Let `txlogs` be the result of [validating](#validate-block) `block` with `prevheader` set to `state.tipheader`.
 2. Let `state′` be `state`.
-3. Remove items from `state′.nonces` where `maxtime_ms < block.header.timestamp_ms`.
-4. Let `state′′` be the result of [applying txlogs](#apply-transaction-list) to `state′`.
-5. Set `state′ <- state′′`.
-6. [Compute utxoroot](#compute-utxoroot) from `state′.utxos`.
-7. Verify `block.header.utxoroot == utxoroot`.
-8. [Compute nonceroot](#compute-nonceroot) from the anchors in `state′.nonces`.
-9. Verify `block.header.nonceroot == nonceroot`.
-10. Set `state′.tipheader <- block.header`.
-11. Add `block.header` to the end of the `state′.refids` list.
-12. Prune `state′.refids` to the number of items specified by `block.header.refscount` by removing the oldest IDs.
-13. Return `state′`.
+3. Let `state′′` be the result of [applying txlogs](#apply-transaction-list) to `state′`.
+4. Set `state′ <- state′′`.
+5. [Compute utxoroot](#compute-utxoroot) from `state′.utxos`.
+6. Verify `block.header.utxoroot == utxoroot`.
+7. Set `state′.tipheader <- block.header`.
+8. Return `state′`.
 
 
 ## Apply transaction list
@@ -407,6 +301,7 @@ Procedure:
 3. Return `state′`.
 
 
+
 ## Apply transaction log
 
 Inputs:
@@ -420,20 +315,13 @@ Output:
 
 Procedure:
 1. Let `state′` be `state`.
-2. For each [nonce entry](zkvm-spec.md#nonce-entry) `n` in `txlog`:
-   1. Verify `n.blockid` is one of the following:
-      - The [ID](#block-id) of `state.initialheader`,
-        or
-      - One of the block ids in `state.refids`.
-   2. Verify `n.nonce_anchor` is _not_ equal to any anchor in `state.nonces`.
-   3. Add the pair `<n.nonce_anchor,n.maxtime_ms>` to `state′.nonces`.
-3. For each [input entry](zkvm-spec.md#input-entry) or [output entry](zkvm-spec.md#output-entry) in `txlog`:
+2. For each [input entry](zkvm-spec.md#input-entry) or [output entry](zkvm-spec.md#output-entry) in `txlog`:
    1. If an input entry,
       verify its ID is in `state′.utxos`,
       then remove it.
    2. If an output entry,
       add its utxo ID to `state′.utxos`.
-4. Return `state′`.
+3. Return `state′`.
 
 Note: utxos may be consumed in the same block,
 or even the same transaction,
@@ -459,20 +347,9 @@ Input:
 - Unordered set `utxos` of [utxo IDs](zkvm-spec.md#utxo).
 
 Output:
-- [Merkle patricia root hash](#merkle-patricia-tree) of the given utxos.
+- [Merkle root hash](zkvm-spec.md#merkle-binary-tree) of the given utxos.
 
 Procedure:
 1. Create a [transcript](zkvm-spec.md#transcript) `T` with label `utxos`.
-2. Return `MPTH(T, utxos)`.
+2. Return `MerkleHash(T, utxos)`.
 
-## Compute nonceroot
-
-Input:
-- Unordered set `nonces` of [nonce anchors](zkvm-spec.md#nonce).
-
-Output:
-- [Merkle patricia root hash](#merkle-patricia-tree) of the given nonce anchors.
-
-Procedure:
-1. Create a [transcript](zkvm-spec.md#transcript) `T` with label `nonces`.
-2. Return `MPTH(T, nonces)`.

--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -1858,7 +1858,7 @@ In contrast, in TxVM:
 
 * [Transaction ID](#transaction-id) is globally unique,
 * [UTXO](#utxo) is **not** unique,
-* [Nonce](#nonce) is globally unique,
+* `Nonce` is globally unique,
 * [Contract](#contract-type) is globally unique,
 * [Value](#value-type) is globally unique.
 

--- a/zkvm/src/blockchain/block.rs
+++ b/zkvm/src/blockchain/block.rs
@@ -15,8 +15,6 @@ pub struct BlockHeader {
     pub timestamp_ms: u64,
     pub txroot: [u8; 32],
     pub utxoroot: [u8; 32],
-    pub nonceroot: [u8; 32],
-    pub refscount: u64,
     pub ext: Vec<u8>,
 }
 
@@ -29,8 +27,6 @@ impl BlockHeader {
         t.commit_u64(b"timestamp_ms", self.timestamp_ms);
         t.commit_bytes(b"txroot", &self.txroot);
         t.commit_bytes(b"utxoroot", &self.utxoroot);
-        t.commit_bytes(b"nonceroot", &self.nonceroot);
-        t.commit_u64(b"refscount", self.refscount);
         t.commit_bytes(b"ext", &self.ext);
 
         let mut result = [0u8; 32];
@@ -46,8 +42,6 @@ impl BlockHeader {
             timestamp_ms: timestamp_ms,
             txroot: [0; 32],
             utxoroot: [0; 32],
-            nonceroot: [0; 32],
-            refscount: refscount,
             ext: Vec::new(),
         }
     }
@@ -67,10 +61,7 @@ impl BlockHeader {
             self.timestamp_ms > prev.timestamp_ms,
             BlockchainError::BadBlockTimestamp,
         )?;
-        check(
-            self.refscount <= prev.refscount + 1,
-            BlockchainError::BadRefscount,
-        )
+        Ok(())
     }
 }
 

--- a/zkvm/src/blockchain/errors.rs
+++ b/zkvm/src/blockchain/errors.rs
@@ -17,9 +17,6 @@ pub enum BlockchainError {
     #[fail(display = "bad block timestamp")]
     BadBlockTimestamp,
 
-    #[fail(display = "bad refscount")]
-    BadRefscount,
-
     #[fail(display = "bad tx timestamp")]
     BadTxTimestamp,
 

--- a/zkvm/src/blockchain/state.rs
+++ b/zkvm/src/blockchain/state.rs
@@ -1,5 +1,5 @@
 use bulletproofs::BulletproofGens;
-use std::collections::{HashSet, VecDeque};
+use std::collections::HashSet;
 
 use super::block::{Block, BlockHeader, BlockID};
 use super::errors::BlockchainError;
@@ -10,8 +10,6 @@ pub struct BlockchainState {
     pub initial: BlockHeader,
     pub tip: BlockHeader,
     pub utxos: HashSet<UTXO>,
-    pub nonces: VecDeque<([u8; 32], u64)>, // xxx need to keep sorted by expiration time; need fast lookup by anchor
-    pub ref_ids: VecDeque<BlockID>,        // xxx need fast lookup by blockID
 
     pub initial_id: BlockID,
 }
@@ -24,8 +22,6 @@ impl BlockchainState {
             initial_id: initialHeader.id(),
             tip: initialHeader,
             utxos: HashSet::new(),
-            nonces: VecDeque::new(),
-            ref_ids: VecDeque::new(),
         }
     }
 
@@ -37,14 +33,6 @@ impl BlockchainState {
         let txlogs = b.validate(&self.tip, bp_gens)?;
         let mut new_state = self.clone();
 
-        // Remove expired nonces.
-        while let Some(nonce_pair) = new_state.nonces.front() {
-            if nonce_pair.1 >= b.header.timestamp_ms {
-                break;
-            }
-            new_state.nonces.pop_front();
-        }
-
         for txlog in txlogs.iter() {
             if let Err(err) = new_state.apply_txlog(&txlog) {
                 return Err(BlockchainError::TxValidation(err));
@@ -55,15 +43,6 @@ impl BlockchainState {
     }
 
     fn apply_txlog(&mut self, txlog: &TxLog) -> Result<(), VMError> {
-        for entry in txlog.iter() {
-            if let Entry::Nonce(blockID, exp_ms, anchor) = entry {
-                // xxx note, when filling in this code, rename the destructing vars to remove the leading _
-                // xxx check blockID is self.initialID or in self.ref_ids
-                // xxx check anchor is not in self.nonces
-                // xxx add (anchor, exp_ms) to self.nonces
-            }
-        }
-
         for entry in txlog.iter() {
             match entry {
                 Entry::Input(contractID) => {

--- a/zkvm/src/contract.rs
+++ b/zkvm/src/contract.rs
@@ -93,15 +93,14 @@ impl Anchor {
         &self.0
     }
 
-    /// Computes a nonce anchor from its components
-    pub fn nonce(blockid: [u8; 32], predicate: &Predicate, maxtime: u64) -> Self {
-        let mut t = Transcript::new(b"ZkVM.nonce");
-        t.commit_bytes(b"blockid", &blockid);
-        t.commit_bytes(b"predicate", predicate.to_point().as_bytes());
-        t.commit_u64(b"maxtime", maxtime);
-        let mut nonce = [0u8; 32];
-        t.challenge_bytes(b"anchor", &mut nonce);
-        Self(nonce)
+    /// Converts raw bytes into an Anchor.
+    ///
+    /// WARNING: This is intended to be used for testing only.
+    /// TBD: add an API later which is tailored to
+    /// (a) specifying initial utxo set, and/or
+    /// (b) per-block minted utxos.
+    pub fn from_raw_bytes(raw_bytes: [u8; 32]) -> Self {
+        Self(raw_bytes)
     }
 
     /// Ratchet the anchor into a new anchor

--- a/zkvm/src/errors.rs
+++ b/zkvm/src/errors.rs
@@ -105,7 +105,7 @@ pub enum VMError {
     StackNotClean,
 
     /// This error occurs when VM's anchor remains unset.
-    #[fail(display = "VM anchor is not set via `input` or `nonce`")]
+    #[fail(display = "VM anchor is not set via `input`")]
     AnchorMissing,
 
     /// This error occurs when VM's deferred schnorr checks fail

--- a/zkvm/src/ops.rs
+++ b/zkvm/src/ops.rs
@@ -42,7 +42,6 @@ pub enum Instruction {
     Input,
     Output(usize),   // payload count
     Contract(usize), // payload count
-    Nonce,
     Log,
     Signtx,
     Call,
@@ -85,15 +84,14 @@ pub enum Opcode {
     Input = 0x1a,
     Output = 0x1b,
     Contract = 0x1c,
-    Nonce = 0x1d,
-    Log = 0x1e,
-    Signtx = 0x1f,
-    Call = 0x20,
-    Select = 0x21,
+    Log = 0x1d,
+    Signtx = 0x1e,
+    Call = 0x1f,
+    Select = 0x20,
     Delegate = MAX_OPCODE,
 }
 
-const MAX_OPCODE: u8 = 0x22;
+const MAX_OPCODE: u8 = 0x21;
 
 impl Opcode {
     /// Converts the opcode to `u8`.
@@ -199,7 +197,6 @@ impl Instruction {
                 let k = program.read_size()?;
                 Ok(Instruction::Contract(k))
             }
-            Opcode::Nonce => Ok(Instruction::Nonce),
             Opcode::Log => Ok(Instruction::Log),
             Opcode::Signtx => Ok(Instruction::Signtx),
             Opcode::Call => Ok(Instruction::Call),
@@ -270,7 +267,6 @@ impl Instruction {
                 write(Opcode::Contract);
                 encoding::write_u32(*k as u32, program);
             }
-            Instruction::Nonce => write(Opcode::Nonce),
             Instruction::Log => write(Opcode::Log),
             Instruction::Signtx => write(Opcode::Signtx),
             Instruction::Call => write(Opcode::Call),

--- a/zkvm/src/program.rs
+++ b/zkvm/src/program.rs
@@ -59,7 +59,6 @@ impl Program {
     def_op!(mintime, Mintime);
     def_op!(mul, Mul);
     def_op!(neg, Neg);
-    def_op!(nonce, Nonce);
     def_op!(or, Or);
     def_op!(output, Output, usize);
     def_op!(range, Range, BitRange);

--- a/zkvm/src/txlog.rs
+++ b/zkvm/src/txlog.rs
@@ -1,7 +1,7 @@
 use curve25519_dalek::ristretto::CompressedRistretto;
 use merlin::Transcript;
 
-use crate::contract::{Anchor, ContractID, Output};
+use crate::contract::{ContractID, Output};
 use crate::merkle::{MerkleItem, MerkleTree};
 use crate::transcript::TranscriptProtocol;
 use crate::vm::TxHeader;
@@ -18,7 +18,6 @@ pub enum Entry {
     Retire(CompressedRistretto, CompressedRistretto),
     Input(ContractID),
     Output(Output),
-    Nonce([u8; 32], u64, Anchor),
     Data(Vec<u8>),
     Import, // TBD: parameters
     Export, // TBD: parameters
@@ -78,11 +77,6 @@ impl MerkleItem for Entry {
             }
             Entry::Output(output) => {
                 t.commit_bytes(b"output", output.id().as_bytes());
-            }
-            Entry::Nonce(blockid, maxtime, anchor) => {
-                t.commit_bytes(b"nonce.b", blockid);
-                t.commit_u64(b"nonce.t", *maxtime);
-                t.commit_bytes(b"nonce.n", anchor.as_bytes());
             }
             Entry::Data(data) => {
                 t.commit_bytes(b"data", data);

--- a/zkvm/tests/zkvm.rs
+++ b/zkvm/tests/zkvm.rs
@@ -14,13 +14,7 @@ use zkvm::keys;
 // TODO(vniu): move builder convenience functions into separate crate,
 // and refactor tests and Token
 trait ProgramHelper {
-    fn issue_helper(
-        &mut self,
-        qty: u64,
-        flv: Scalar,
-        issuance_pred: Predicate,
-        nonce_pred: Predicate,
-    ) -> &mut Self;
+    fn issue_helper(&mut self, qty: u64, flv: Scalar, issuance_pred: Predicate) -> &mut Self;
 
     fn input_helper(&mut self, qty: u64, flv: Scalar, pred: Predicate) -> &mut Self;
 
@@ -30,19 +24,8 @@ trait ProgramHelper {
 }
 
 impl ProgramHelper for Program {
-    fn issue_helper(
-        &mut self,
-        qty: u64,
-        flv: Scalar,
-        issuance_pred: Predicate,
-        nonce_pred: Predicate,
-    ) -> &mut Self {
-        let dummy_block_id = Data::Opaque([0xffu8; 32].to_vec());
-        self.push(nonce_pred)
-            .push(dummy_block_id)
-            .nonce()
-            .sign_tx() // stack is clean
-            .push(Commitment::blinded_with_factor(qty, Scalar::from(1u64))) // stack: qty
+    fn issue_helper(&mut self, qty: u64, flv: Scalar, issuance_pred: Predicate) -> &mut Self {
+        self.push(Commitment::blinded_with_factor(qty, Scalar::from(1u64))) // stack: qty
             .var() // stack: qty-var
             .push(Commitment::unblinded(flv)) // stack: qty-var, flv
             .var() // stack: qty-var, flv-var
@@ -119,13 +102,8 @@ fn make_flavor() -> (Scalar, Predicate, Scalar) {
 
 /// Creates an Output contract with given quantity, flavor, and predicate.
 fn make_output(qty: u64, flv: Scalar, pred: Predicate) -> Contract {
-    let anchor = Anchor::nonce(
-        [0u8; 32],
-        &Predicate::Opaque(RISTRETTO_BASEPOINT_COMPRESSED),
-        0,
-    );
     Contract {
-        anchor,
+        anchor: Anchor::from_raw_bytes([0u8; 32]),
         payload: vec![PortableItem::Value(Value {
             qty: Commitment::blinded(qty),
             flv: Commitment::blinded(flv),
@@ -174,58 +152,6 @@ fn build_and_verify(program: Program, keys: &Vec<Scalar>) -> Result<TxID, VMErro
 
     let vtx = Verifier::verify_tx(&tx, &bp_gens)?;
     Ok(vtx.id)
-}
-
-fn issue_contract(
-    qty: u64,
-    flv: Scalar,
-    issuance_pred: Predicate,
-    nonce_pred: Predicate,
-    output_pred: Predicate,
-) -> Program {
-    Program::build(|p| {
-        p.issue_helper(qty, flv, issuance_pred, nonce_pred) // stack: issued-val
-            .output_helper(output_pred) // stack: empty
-    })
-}
-
-#[test]
-fn issue() {
-    // Generate predicates
-    let (predicates, mut scalars) = generate_predicates(2);
-    let (issuance_scalar, issuance_pred, flavor) = make_flavor();
-    scalars.push(issuance_scalar);
-
-    let correct_program = issue_contract(
-        1u64,
-        flavor,
-        issuance_pred,
-        predicates[0].clone(), // nonce predicate
-        predicates[1].clone(), // output predicate
-    );
-
-    match build_and_verify(correct_program, &scalars) {
-        Err(err) => return assert!(false, err.to_string()),
-        Ok(txid) => {
-            // Check txid
-            assert_eq!(
-                "316f835973819a8cf6219010faf712bd17a1fe6fa2cc6350e4d96483b2065d82",
-                hex::encode(txid.0)
-            );
-        }
-    }
-
-    let wrong_program = issue_contract(
-        1u64,
-        flavor,
-        predicates[0].clone(), // WRONG issuance predicate
-        predicates[0].clone(), // nonce predicate
-        predicates[1].clone(), // output predicate
-    );
-
-    if build_and_verify(wrong_program, &scalars).is_ok() {
-        panic!("Issuing with wrong issuance predicate should fail, but didn't");
-    }
 }
 
 fn spend_1_1_contract(
@@ -447,14 +373,13 @@ fn issue_and_spend_contract(
     output_2: u64,
     flv: Scalar,
     issuance_pred: Predicate,
-    nonce_pred: Predicate,
     input_pred: Predicate,
     output_1_pred: Predicate,
     output_2_pred: Predicate,
 ) -> Program {
     Program::build(|p| {
-        p.issue_helper(issue_qty, flv, issuance_pred, nonce_pred) // stack: issued-val
-            .input_helper(input_qty, flv, input_pred) // stack: issued-val, input-val
+        p.input_helper(input_qty, flv, input_pred) // stack: issued-val, input-val
+            .issue_helper(issue_qty, flv, issuance_pred) // stack: issued-val
             .cloak_helper(2, vec![(output_1, flv), (output_2, flv)]) // stack: output-1, output-2
             .output_helper(output_2_pred) // stack: output-1
             .output_helper(output_1_pred) // stack: empty
@@ -464,7 +389,7 @@ fn issue_and_spend_contract(
 #[test]
 fn issue_and_spend() {
     // Generate predicates and flavor
-    let (predicates, mut scalars) = generate_predicates(4);
+    let (predicates, mut scalars) = generate_predicates(3);
     let (issuance_scalar, issuance_pred, flavor) = make_flavor();
     scalars.push(issuance_scalar);
 
@@ -475,10 +400,9 @@ fn issue_and_spend() {
         1u64,
         flavor,
         issuance_pred.clone(),
-        predicates[0].clone(), // nonce predicate
-        predicates[1].clone(), // input predicate
-        predicates[2].clone(), // output 1 predicate
-        predicates[3].clone(), // output 2 predicate
+        predicates[0].clone(), // input predicate
+        predicates[1].clone(), // output 1 predicate
+        predicates[2].clone(), // output 2 predicate
     );
 
     match build_and_verify(correct_program, &scalars) {
@@ -493,10 +417,9 @@ fn issue_and_spend() {
         1u64,
         flavor,
         issuance_pred,
-        predicates[0].clone(), // nonce predicate
-        predicates[1].clone(), // input predicate
-        predicates[2].clone(), // output 1 predicate
-        predicates[3].clone(), // output 2 predicate
+        predicates[0].clone(), // input predicate
+        predicates[1].clone(), // output 1 predicate
+        predicates[2].clone(), // output 2 predicate
     );
 
     if build_and_verify(wrong_program, &scalars).is_ok() {


### PR DESCRIPTION
This removes nonces from the design. This dramatically simplifies blockchain state and validation rules: every tx must spend an input to be unique. Initial anchoring can be provided in a number of ways: pegged assets from a parent chain, and/or minted synthetic nonce-units at each block, etc. See #230 and #249 for details. To bootstrap anchoring, the initial block can start with an initial UTXO set (this API is necessary to have until we have minteable nonce-units (if at all), and even then it may be useful in its own right).

UTXO set commitment is changed to a normal merkle tree (instead of radix/patricia trie), in order to support utreexo (see #258). The state machine spec is still assuming presence of the entire set, this will be updated later.

Closes #262.
Closes #263.