### PR TITLE
zkvm/blockchain: implement BlockchainState::apply_txlog

### DIFF
--- a/zkvm/src/blockchain/state.rs
+++ b/zkvm/src/blockchain/state.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 
 use super::block::{Block, BlockHeader, BlockID};
 use super::errors::BlockchainError;
-use crate::{Entry, TxID, TxLog, VMError, UTXO};
+use crate::{Entry, TxLog, VMError, UTXO};
 
 #[derive(Clone)]
 pub struct BlockchainState {
@@ -51,7 +51,7 @@ impl BlockchainState {
                     if self.utxos.contains(&utxo) {
                         self.utxos.remove(&utxo);
                     } else {
-                        return Err(VMError::FormatError);
+                        return Err(VMError::InvalidInput);
                     }
                 }
 

--- a/zkvm/src/contract.rs
+++ b/zkvm/src/contract.rs
@@ -5,6 +5,7 @@ use crate::encoding;
 use crate::encoding::SliceReader;
 use crate::errors::VMError;
 use crate::predicate::Predicate;
+use crate::txlog::UTXO;
 use crate::types::{Data, Value};
 
 /// Prefix for the data type in the Output Structure
@@ -116,6 +117,11 @@ impl ContractID {
     /// Provides a view into the contract ID's bytes.
     pub fn as_bytes(&self) -> &[u8] {
         &self.0
+    }
+
+    /// Returns the contractID as a UTXO
+    pub fn as_utxo(&self) -> UTXO {
+        UTXO(self.0)
     }
 
     fn from_serialized_contract(bytes: &[u8]) -> Self {

--- a/zkvm/src/contract.rs
+++ b/zkvm/src/contract.rs
@@ -5,7 +5,6 @@ use crate::encoding;
 use crate::encoding::SliceReader;
 use crate::errors::VMError;
 use crate::predicate::Predicate;
-use crate::txlog::UTXO;
 use crate::types::{Data, Value};
 
 /// Prefix for the data type in the Output Structure
@@ -19,7 +18,7 @@ pub const VALUE_TYPE: u8 = 0x01;
 pub struct Anchor([u8; 32]);
 
 /// A unique identifier for a contract.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Eq, Hash, Debug, PartialEq)]
 pub struct ContractID([u8; 32]);
 
 /// A ZkVM contract that holds a _payload_ (a list of portable items) protected by a _predicate_.
@@ -117,11 +116,6 @@ impl ContractID {
     /// Provides a view into the contract ID's bytes.
     pub fn as_bytes(&self) -> &[u8] {
         &self.0
-    }
-
-    /// Returns the contractID as a UTXO
-    pub fn as_utxo(&self) -> UTXO {
-        UTXO(self.0)
     }
 
     fn from_serialized_contract(bytes: &[u8]) -> Self {

--- a/zkvm/src/errors.rs
+++ b/zkvm/src/errors.rs
@@ -154,4 +154,8 @@ pub enum VMError {
     /// This error occurs when key aggregation fails.
     #[fail(display = "Key aggregation failed")]
     KeyAggregationFailed,
+
+    /// This error occurs when an input is invalid.
+    #[fail(display = "Input is invalid")]
+    InvalidInput,
 }

--- a/zkvm/src/lib.rs
+++ b/zkvm/src/lib.rs
@@ -33,7 +33,7 @@ pub use self::program::Program;
 pub use self::prover::Prover;
 pub use self::scalar_witness::ScalarWitness;
 pub use self::transcript::TranscriptProtocol;
-pub use self::txlog::{Entry, TxID, TxLog, UTXO};
+pub use self::txlog::{Entry, TxID, TxLog};
 pub use self::types::{Data, Item, Value, WideValue};
 pub use self::verifier::Verifier;
 pub use self::vm::{Tx, TxHeader, VerifiedTx};

--- a/zkvm/src/txlog.rs
+++ b/zkvm/src/txlog.rs
@@ -33,17 +33,6 @@ impl MerkleItem for TxID {
     }
 }
 
-/// UTXO is a unique 32-byte identifier of a transaction output
-#[derive(Copy, Clone, Eq, Hash, PartialEq, Debug)]
-pub struct UTXO(pub [u8; 32]);
-
-impl UTXO {
-    /// Computes UTXO identifier from an output.
-    pub fn from_output(output: &Output) -> Self {
-        output.id().as_utxo()
-    }
-}
-
 impl TxID {
     /// Computes TxID from a tx log
     pub fn from_log(list: &[Entry]) -> Self {

--- a/zkvm/src/txlog.rs
+++ b/zkvm/src/txlog.rs
@@ -38,14 +38,9 @@ impl MerkleItem for TxID {
 pub struct UTXO(pub [u8; 32]);
 
 impl UTXO {
-    /// Computes UTXO identifier from an output and transaction id.
-    pub fn from_output(output: &[u8], txid: &TxID) -> Self {
-        let mut t = Transcript::new(b"ZkVM.utxo");
-        t.commit_bytes(b"txid", &txid.0);
-        t.commit_bytes(b"output", &output);
-        let mut utxo = UTXO([0u8; 32]);
-        t.challenge_bytes(b"id", &mut utxo.0);
-        utxo
+    /// Computes UTXO identifier from an output.
+    pub fn from_output(output: &Output) -> Self {
+        output.id().as_utxo()
     }
 }
 
@@ -72,8 +67,8 @@ impl MerkleItem for Entry {
                 t.commit_point(b"retire.q", q);
                 t.commit_point(b"retire.f", f);
             }
-            Entry::Input(id) => {
-                t.commit_bytes(b"input", id.as_bytes());
+            Entry::Input(contract) => {
+                t.commit_bytes(b"input", contract.as_bytes());
             }
             Entry::Output(output) => {
                 t.commit_bytes(b"output", output.id().as_bytes());

--- a/zkvm/tests/zkvm.rs
+++ b/zkvm/tests/zkvm.rs
@@ -1,7 +1,6 @@
 use bulletproofs::{BulletproofGens, PedersenGens};
 use curve25519_dalek::constants::RISTRETTO_BASEPOINT_COMPRESSED;
 use curve25519_dalek::scalar::Scalar;
-use hex;
 use musig::{Signature, VerificationKey};
 
 use zkvm::{


### PR DESCRIPTION
Changes UTXO representation to match contract ID and implements `apply_txlog`, removing inputs and adding outputs to the UTXO set.