### PR TITLE
zkvm/blockchain: compute utxo and tx root

### DIFF
--- a/zkvm/src/blockchain/block.rs
+++ b/zkvm/src/blockchain/block.rs
@@ -37,18 +37,14 @@ impl BlockHeader {
         BlockID(result)
     }
 
-    pub fn make_initial(
-        timestamp_ms: u64,
-        refscount: u64,
-        utxos: Option<&Vec<ContractID>>,
-    ) -> BlockHeader {
+    pub fn make_initial(timestamp_ms: u64, refscount: u64, utxos: &Vec<ContractID>) -> BlockHeader {
         BlockHeader {
             version: 1,
             height: 1,
             prev: BlockID([0; 32]),
             timestamp_ms: timestamp_ms,
-            txroot: [0; 32],
-            utxoroot: utxos.map_or([0; 32], |u| Root::utxo(u).0),
+            txroot: Root::tx(&[]).0,
+            utxoroot: Root::utxo(utxos).0,
             ext: Vec::new(),
         }
     }

--- a/zkvm/src/blockchain/block.rs
+++ b/zkvm/src/blockchain/block.rs
@@ -130,6 +130,6 @@ impl Root {
 
     /// Computes the Merkle utxoroot
     pub fn utxo(utxos: &[ContractID]) -> Root {
-        Root(MerkleTree::root(b"utxos", utxos))
+        Root(MerkleTree::root(b"ZkVM.utxoroot", utxos))
     }
 }

--- a/zkvm/src/blockchain/block.rs
+++ b/zkvm/src/blockchain/block.rs
@@ -68,6 +68,7 @@ impl BlockHeader {
             self.timestamp_ms > prev.timestamp_ms,
             BlockchainError::BadBlockTimestamp,
         )?;
+        // TODO: execute transaction list and verify txroot
         Ok(())
     }
 }

--- a/zkvm/src/blockchain/block.rs
+++ b/zkvm/src/blockchain/block.rs
@@ -125,7 +125,7 @@ impl Block {
 impl Root {
     /// Computes the Merkle txroot
     pub fn tx(txids: &[TxID]) -> Root {
-        Root(MerkleTree::root(b"transaction_ids", txids))
+        Root(MerkleTree::root(b"ZkVM.txroot", txids))
     }
 
     /// Computes the Merkle utxoroot

--- a/zkvm/src/blockchain/state.rs
+++ b/zkvm/src/blockchain/state.rs
@@ -9,19 +9,23 @@ use crate::{ContractID, Entry, TxLog, VMError};
 pub struct BlockchainState {
     pub initial: BlockHeader,
     pub tip: BlockHeader,
-    pub utxos: HashSet<ContractID>,
+    pub utxos: Vec<ContractID>,
 
     pub initial_id: BlockID,
 }
 
 impl BlockchainState {
-    pub fn make_initial(timestamp_ms: u64, refscount: u64) -> BlockchainState {
-        let initialHeader = BlockHeader::make_initial(timestamp_ms, refscount);
+    pub fn make_initial(
+        timestamp_ms: u64,
+        refscount: u64,
+        utxos: Option<Vec<ContractID>>,
+    ) -> BlockchainState {
+        let initialHeader = BlockHeader::make_initial(timestamp_ms, refscount, utxos.as_ref());
         BlockchainState {
             initial: initialHeader.clone(),
             initial_id: initialHeader.id(),
             tip: initialHeader,
-            utxos: HashSet::new(),
+            utxos: utxos.map_or(Vec::new(), |u| u),
         }
     }
 
@@ -47,14 +51,15 @@ impl BlockchainState {
             match entry {
                 // Remove input from UTXO set
                 Entry::Input(input) => {
-                    if !self.utxos.remove(&input) {
-                        return Err(VMError::InvalidInput);
-                    }
+                    match self.utxos.iter().position(|x| x == input) {
+                        Some(pos) => self.utxos.remove(pos),
+                        None => return Err(VMError::InvalidInput),
+                    };
                 }
 
                 // Add output entry to UTXO set
                 Entry::Output(output) => {
-                    self.utxos.insert(output.id());
+                    self.utxos.push(output.id());
                 }
                 _ => {}
             }
@@ -92,7 +97,7 @@ mod tests {
 
     #[test]
     fn test_apply_txlog() {
-        let mut state = BlockchainState::make_initial(0u64, 0u64);
+        let mut state = BlockchainState::make_initial(0u64, 0u64, None);
 
         // Add two outputs
         let (output0, output1) = (Output::new(rand_contract()), Output::new(rand_contract()));

--- a/zkvm/src/blockchain/state.rs
+++ b/zkvm/src/blockchain/state.rs
@@ -18,14 +18,14 @@ impl BlockchainState {
     pub fn make_initial(
         timestamp_ms: u64,
         refscount: u64,
-        utxos: Option<Vec<ContractID>>,
+        utxos: Vec<ContractID>,
     ) -> BlockchainState {
-        let initialHeader = BlockHeader::make_initial(timestamp_ms, refscount, utxos.as_ref());
+        let initialHeader = BlockHeader::make_initial(timestamp_ms, refscount, &utxos);
         BlockchainState {
             initial: initialHeader.clone(),
             initial_id: initialHeader.id(),
             tip: initialHeader,
-            utxos: utxos.map_or(Vec::new(), |u| u),
+            utxos: utxos,
         }
     }
 
@@ -97,7 +97,7 @@ mod tests {
 
     #[test]
     fn test_apply_txlog() {
-        let mut state = BlockchainState::make_initial(0u64, 0u64, None);
+        let mut state = BlockchainState::make_initial(0u64, 0u64, Vec::new());
 
         // Add two outputs
         let (output0, output1) = (Output::new(rand_contract()), Output::new(rand_contract()));

--- a/zkvm/src/contract.rs
+++ b/zkvm/src/contract.rs
@@ -4,6 +4,7 @@ use crate::constraints::Commitment;
 use crate::encoding;
 use crate::encoding::SliceReader;
 use crate::errors::VMError;
+use crate::merkle::MerkleItem;
 use crate::predicate::Predicate;
 use crate::types::{Data, Value};
 
@@ -225,5 +226,11 @@ impl Contract {
         let id = ContractID::from_serialized_contract(serialized_contract);
 
         Ok((contract, id))
+    }
+}
+
+impl MerkleItem for ContractID {
+    fn commit(&self, t: &mut Transcript) {
+        t.commit_bytes(b"utxo", self.as_bytes());
     }
 }


### PR DESCRIPTION
Makes changes to use an ordered `Vec` for the UTXO set (per the spec change in #278), and implements computing the utxo and tx root.