### PR TITLE
zkvm: implement guaranteed optimization for cleartext constraints

### DIFF
--- a/zkvm/src/constraints.rs
+++ b/zkvm/src/constraints.rs
@@ -171,6 +171,13 @@ impl Constraint {
         }
     }
 
+    /// Returns the secret assignment to this constraint (true or false),
+    /// based on the assignments to the variables inside the underlying Expressions.
+    /// Returns `None` if any underlying variable does not have an assignment.
+    pub fn assignment(&self) -> Option<bool> {
+        self.eval()
+    }
+
     /// Evaluates the constraint using the optional scalar witness data in the underlying `Expression`s.
     /// Returns None if the witness is missing in any expression.
     fn eval(&self) -> Option<bool> {

--- a/zkvm/src/errors.rs
+++ b/zkvm/src/errors.rs
@@ -162,4 +162,8 @@ pub enum VMError {
     /// This error occurs when an input is invalid.
     #[fail(display = "Input is invalid")]
     InvalidInput,
+
+    /// This error occurs when a false cleartext constraint is verified.
+    #[fail(display = "Cleartext constraint is false")]
+    CleartextConstraintFalse,
 }

--- a/zkvm/src/prover.rs
+++ b/zkvm/src/prover.rs
@@ -2,7 +2,7 @@ use bulletproofs::r1cs;
 use bulletproofs::{BulletproofGens, PedersenGens};
 use curve25519_dalek::ristretto::CompressedRistretto;
 use merlin::Transcript;
-use musig::{Signature, VerificationKey};
+use musig::VerificationKey;
 use std::collections::VecDeque;
 
 use crate::constraints::Commitment;

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -279,14 +279,14 @@ where
     fn or(&mut self) -> Result<(), VMError> {
         let c2 = self.pop_item()?.to_constraint()?;
         let c1 = self.pop_item()?.to_constraint()?;
-        let c3 = Constraint::Or(Box::new(c1), Box::new(c2));
+        let c3 = Constraint::or(c1, c2);
         self.push_item(c3);
         Ok(())
     }
 
     fn not(&mut self) -> Result<(), VMError> {
         let c1 = self.pop_item()?.to_constraint()?;
-        let c2 = Constraint::Not(Box::new(c1));
+        let c2 = Constraint::not(c1);
         self.push_item(c2);
         Ok(())
     }

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -256,7 +256,7 @@ where
     fn eq(&mut self) -> Result<(), VMError> {
         let expr2 = self.pop_item()?.to_expression()?;
         let expr1 = self.pop_item()?.to_expression()?;
-        let constraint = Constraint::Eq(expr1, expr2);
+        let constraint = Constraint::eq(expr1, expr2);
         self.push_item(constraint);
         Ok(())
     }
@@ -271,7 +271,7 @@ where
     fn and(&mut self) -> Result<(), VMError> {
         let c2 = self.pop_item()?.to_constraint()?;
         let c1 = self.pop_item()?.to_constraint()?;
-        let c3 = Constraint::And(Box::new(c1), Box::new(c2));
+        let c3 = Constraint::and(c1, c2);
         self.push_item(c3);
         Ok(())
     }


### PR DESCRIPTION
Closes #252

Partly depends on https://github.com/dalek-cryptography/bulletproofs/pull/271 — if that PR 271 is merged, we can replace `PartialEq` implementation for `Expression` with a simple `#[derive(PartialEq)]`.