### PR TITLE
zkvm+cloak: update for Bulletproofs API change #270

### DIFF
--- a/spacesuit/Cargo.toml
+++ b/spacesuit/Cargo.toml
@@ -12,7 +12,7 @@ curve25519-dalek = { version = "1.0.1", features = ["serde"] }
 
 [dependencies.bulletproofs]
 git = "https://github.com/dalek-cryptography/bulletproofs"
-branch = "oleg/one-level-randomization"
+branch = "develop"
 features = ["yoloproofs"]
 
 [dev-dependencies]

--- a/spacesuit/Cargo.toml
+++ b/spacesuit/Cargo.toml
@@ -12,7 +12,7 @@ curve25519-dalek = { version = "1.0.1", features = ["serde"] }
 
 [dependencies.bulletproofs]
 git = "https://github.com/dalek-cryptography/bulletproofs"
-branch = "develop"
+branch = "oleg/one-level-randomization"
 features = ["yoloproofs"]
 
 [dev-dependencies]

--- a/spacesuit/src/cloak.rs
+++ b/spacesuit/src/cloak.rs
@@ -1,12 +1,12 @@
 use crate::{mix::k_mix, range_proof};
 use bit_range::BitRange;
-use bulletproofs::r1cs::{ConstraintSystem, R1CSError};
+use bulletproofs::r1cs::{R1CSError, RandomizableConstraintSystem};
 use shuffle::{padded_shuffle, value_shuffle};
 use value::AllocatedValue;
 
 /// Enforces that the outputs are a valid rearrangement of the inputs, following the
 /// soundness and secrecy requirements in the [Cloak specification](../spec.md).
-pub fn cloak<CS: ConstraintSystem>(
+pub fn cloak<CS: RandomizableConstraintSystem>(
     cs: &mut CS,
     inputs: Vec<AllocatedValue>,
     outputs: Vec<AllocatedValue>,
@@ -49,7 +49,7 @@ pub fn cloak<CS: ConstraintSystem>(
 /// Enforces that the outputs are either a merge of the inputs: `D = A + B && C = 0`,
 /// or the outputs are equal to the inputs `C = A && D = B`. See spec for more details.
 /// Works for `k` inputs and `k` outputs.
-fn merge<CS: ConstraintSystem>(
+fn merge<CS: RandomizableConstraintSystem>(
     cs: &mut CS,
     inputs: Vec<AllocatedValue>,
 ) -> Result<(Vec<AllocatedValue>, Vec<AllocatedValue>), R1CSError> {
@@ -63,7 +63,7 @@ fn merge<CS: ConstraintSystem>(
 /// Note: the `split` gadget is the same thing as a `merge` gadget, but "backwards".
 /// This means that if you reverse all of the commitment vectors, and switch the
 /// inputs and outputs of a `merge` gadget, then you have a `split` gadget.
-fn split<CS: ConstraintSystem>(
+fn split<CS: RandomizableConstraintSystem>(
     cs: &mut CS,
     mut inputs: Vec<AllocatedValue>,
 ) -> Result<(Vec<AllocatedValue>, Vec<AllocatedValue>), R1CSError> {

--- a/spacesuit/src/mix.rs
+++ b/spacesuit/src/mix.rs
@@ -2,7 +2,9 @@
 
 use crate::signed_integer::SignedInteger;
 use crate::value::{AllocatedValue, Value};
-use bulletproofs::r1cs::{ConstraintSystem, R1CSError, RandomizedConstraintSystem};
+use bulletproofs::r1cs::{
+    ConstraintSystem, R1CSError, RandomizableConstraintSystem, RandomizedConstraintSystem,
+};
 use curve25519_dalek::scalar::Scalar;
 use std::iter;
 use subtle::{ConditionallySelectable, ConstantTimeEq};
@@ -10,7 +12,7 @@ use subtle::{ConditionallySelectable, ConstantTimeEq};
 /// Enforces that the outputs are either a merge of the inputs :`D = A + B && C = 0`,
 /// or the outputs are equal to the inputs `C = A && D = B`. See spec for more details.
 /// Works for 2 inputs and 2 outputs.
-pub fn mix<CS: ConstraintSystem>(
+pub fn mix<CS: RandomizableConstraintSystem>(
     cs: &mut CS,
     A: AllocatedValue,
     B: AllocatedValue,
@@ -41,7 +43,7 @@ pub fn mix<CS: ConstraintSystem>(
 /// * a vector of `k` sorted `AllocatedValue`s that are the inputs to the `mix` gadget
 /// * a vector of `k` `AllocatedValue`s that are the outputs to the `mix` gadget,
 ///   such that each output is either zero, or the sum of all of the `Values` of one type.
-pub fn k_mix<CS: ConstraintSystem>(
+pub fn k_mix<CS: RandomizableConstraintSystem>(
     cs: &mut CS,
     inputs: Vec<AllocatedValue>,
 ) -> Result<(Vec<AllocatedValue>, Vec<AllocatedValue>), R1CSError> {
@@ -56,7 +58,7 @@ pub fn k_mix<CS: ConstraintSystem>(
 }
 
 // Calls `k` mix gadgets, using mix_in and mix_mid as inputs, and mix_mid and mix_out as outputs.
-fn call_mix_gadget<CS: ConstraintSystem>(
+fn call_mix_gadget<CS: RandomizableConstraintSystem>(
     cs: &mut CS,
     mix_in: &Vec<AllocatedValue>,
     mix_mid: &Vec<AllocatedValue>,
@@ -98,7 +100,7 @@ fn call_mix_gadget<CS: ConstraintSystem>(
 // * a vector of `AllocatedValue`s for the input values of a k-mix gadget
 // * a vector of `AllocatedValue`s for the middle values of a k-mix gadget
 // * a vector of `AllocatedValue`s for the output values of a k-mix gadget
-fn make_intermediate_values<CS: ConstraintSystem>(
+fn make_intermediate_values<CS: RandomizableConstraintSystem>(
     inputs: &Vec<AllocatedValue>,
     cs: &mut CS,
 ) -> Result<
@@ -132,7 +134,7 @@ fn make_intermediate_values<CS: ConstraintSystem>(
 // * a vector of `AllocatedValue`s that is a reordering of the inputs
 //   where all `AllocatedValues` have been grouped according to flavor
 // * a vector of `Value`s that were used to create the output `AllocatedValue`s
-fn order_by_flavor<CS: ConstraintSystem>(
+fn order_by_flavor<CS: RandomizableConstraintSystem>(
     inputs: &Vec<Value>,
     cs: &mut CS,
 ) -> Result<(Vec<AllocatedValue>, Vec<Value>), R1CSError> {
@@ -176,7 +178,7 @@ fn order_by_flavor<CS: ConstraintSystem>(
 //   where `Value`s of the same flavor are combined and `Value`s of different flavors
 //   are moved without modification. (See `mix.rs` for more information on 2-mix gadgets.)
 // * a vector of the `AllocatedValue`s that are only outputs of 2-mix gadgets.
-fn combine_by_flavor<CS: ConstraintSystem>(
+fn combine_by_flavor<CS: RandomizableConstraintSystem>(
     inputs: &Vec<Value>,
     cs: &mut CS,
 ) -> Result<(Vec<AllocatedValue>, Vec<AllocatedValue>), R1CSError> {

--- a/token/Cargo.toml
+++ b/token/Cargo.toml
@@ -15,8 +15,7 @@ curve25519-dalek = { version = "1.0.1", features = ["serde"] }
 
 [dependencies.bulletproofs]
 git = "https://github.com/dalek-cryptography/bulletproofs"
-branch = "develop"
-#path = "../../dalek/bulletproofs"
+branch = "oleg/one-level-randomization"
 features = ["yoloproofs"]
 
 [dependencies.spacesuit]

--- a/token/Cargo.toml
+++ b/token/Cargo.toml
@@ -15,7 +15,7 @@ curve25519-dalek = { version = "1.0.1", features = ["serde"] }
 
 [dependencies.bulletproofs]
 git = "https://github.com/dalek-cryptography/bulletproofs"
-branch = "oleg/one-level-randomization"
+branch = "develop"
 features = ["yoloproofs"]
 
 [dependencies.spacesuit]

--- a/zkvm/Cargo.toml
+++ b/zkvm/Cargo.toml
@@ -22,8 +22,7 @@ serde = { version = "1.0", features=["derive"] }
 
 [dependencies.bulletproofs]
 git = "https://github.com/dalek-cryptography/bulletproofs"
-branch = "develop"
-#path = "../../dalek/bulletproofs"
+branch = "oleg/one-level-randomization"
 features = ["yoloproofs"]
 
 [dependencies.spacesuit]

--- a/zkvm/Cargo.toml
+++ b/zkvm/Cargo.toml
@@ -19,7 +19,6 @@ subtle = "2"
 curve25519-dalek = { version = "1.0.1", features = ["serde"] }
 serde = { version = "1.0", features=["derive"] }
 
-
 [dependencies.bulletproofs]
 git = "https://github.com/dalek-cryptography/bulletproofs"
 branch = "oleg/one-level-randomization"

--- a/zkvm/Cargo.toml
+++ b/zkvm/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0", features=["derive"] }
 
 [dependencies.bulletproofs]
 git = "https://github.com/dalek-cryptography/bulletproofs"
-branch = "oleg/one-level-randomization"
+branch = "develop"
 features = ["yoloproofs"]
 
 [dependencies.spacesuit]

--- a/zkvm/src/constraints.rs
+++ b/zkvm/src/constraints.rs
@@ -76,7 +76,10 @@ pub struct CommitmentWitness {
 impl Constraint {
     /// Generates and adds to R1CS constraints that enforce that the self evaluates to true.
     /// Implements the logic behind `verify` instruction.
-    pub fn verify<CS: r1cs::ConstraintSystem>(self, cs: &mut CS) -> Result<(), VMError> {
+    pub fn verify<CS: r1cs::RandomizableConstraintSystem>(
+        self,
+        cs: &mut CS,
+    ) -> Result<(), VMError> {
         cs.specify_randomized_constraints(move |cs| {
             // Flatten the constraint into one expression
             // Note: cloning because we can't move out of captured variable in an `Fn` closure,

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -25,7 +25,7 @@ pub const CURRENT_VERSION: u64 = 1;
 
 pub(crate) struct VM<'d, CS, D>
 where
-    CS: r1cs::ConstraintSystem,
+    CS: r1cs::RandomizableConstraintSystem,
     D: Delegate<CS>,
 {
     mintime_ms: u64,
@@ -48,7 +48,7 @@ where
     txlog: TxLog,
 }
 
-pub(crate) trait Delegate<CS: r1cs::ConstraintSystem> {
+pub(crate) trait Delegate<CS: r1cs::RandomizableConstraintSystem> {
     type RunType;
 
     /// Adds a Commitment to the underlying constraint system, producing a high-level variable
@@ -85,7 +85,7 @@ pub(crate) trait Delegate<CS: r1cs::ConstraintSystem> {
 
 impl<'d, CS, D> VM<'d, CS, D>
 where
-    CS: r1cs::ConstraintSystem,
+    CS: r1cs::RandomizableConstraintSystem,
     D: Delegate<CS>,
 {
     /// Instantiates a new VM instance.
@@ -619,7 +619,7 @@ where
 // Utility methods
 impl<'d, CS, D> VM<'d, CS, D>
 where
-    CS: r1cs::ConstraintSystem,
+    CS: r1cs::RandomizableConstraintSystem,
     D: Delegate<CS>,
 {
     fn pop_item(&mut self) -> Result<Item, VMError> {


### PR DESCRIPTION
This PR in Bulletproofs changes the trait definitions, decoupling the randomization from general ConstraintSystem functionality: https://github.com/dalek-cryptography/bulletproofs/pull/270

Before it is merged (which is a breaking change), we need to update Spacesuit and ZkVM to use this API and merge that in lockstep with Bulletproofs.
