### PR TITLE
slidechain: make CI runs optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ branches:
     - main
 matrix:
   fast_finish: true
+  allow_failures:
+  - env: ALLOW_FAILURES=1
   include:
   - language: ruby
     ruby: 2.3
@@ -11,6 +13,7 @@ matrix:
   - language: go
     go: 1.11
     install: true
+    env: ALLOW_FAILURES=1
     before_script:
       - go vet ./slidechain/...
       - test `gofmt -s -l ./slidechain | grep -vF /vendor/ | wc -l` -eq 0


### PR DESCRIPTION
We are not currently working on Slidechain actively, so it's fine to allow failures to not block other development due to Horizon's timeout issues. We can re-enable them again if/when we get back to it.