### PR TITLE
zkvm: remove import/export instructions

### DIFF
--- a/zkvm/docs/zkvm-spec.md
+++ b/zkvm/docs/zkvm-spec.md
@@ -1269,7 +1269,6 @@ Merges and splits `m` [wide values](#wide-value-type) into `n` [values](#value-t
 Immediate data `m` and `n` are encoded as two [LE32](#le32)s.
 
 
-
 ### Contract instructions
 
 

--- a/zkvm/src/ops.rs
+++ b/zkvm/src/ops.rs
@@ -37,8 +37,6 @@ pub enum Instruction {
     Borrow,
     Retire,
     Cloak(usize, usize), // M inputs, N outputs
-    Import,
-    Export,
     Input,
     Output(usize),   // payload count
     Contract(usize), // payload count
@@ -78,18 +76,16 @@ pub enum Opcode {
     Borrow = 0x15,
     Retire = 0x16,
     Cloak = 0x17,
-    Import = 0x18,
-    Export = 0x19,
-    Input = 0x1a,
-    Output = 0x1b,
-    Contract = 0x1c,
-    Log = 0x1d,
-    Signtx = 0x1e,
-    Call = 0x1f,
+    Input = 0x18,
+    Output = 0x19,
+    Contract = 0x1a,
+    Log = 0x1b,
+    Signtx = 0x1c,
+    Call = 0x1d,
     Delegate = MAX_OPCODE,
 }
 
-const MAX_OPCODE: u8 = 0x20;
+const MAX_OPCODE: u8 = 0x1e;
 
 impl Opcode {
     /// Converts the opcode to `u8`.
@@ -184,8 +180,6 @@ impl Instruction {
                 let n = program.read_size()?;
                 Ok(Instruction::Cloak(m, n))
             }
-            Opcode::Import => Ok(Instruction::Import),
-            Opcode::Export => Ok(Instruction::Export),
             Opcode::Input => Ok(Instruction::Input),
             Opcode::Output => {
                 let k = program.read_size()?;
@@ -249,8 +243,6 @@ impl Instruction {
                 encoding::write_u32(*m as u32, program);
                 encoding::write_u32(*n as u32, program);
             }
-            Instruction::Import => write(Opcode::Import),
-            Instruction::Export => write(Opcode::Export),
             Instruction::Input => write(Opcode::Input),
             Instruction::Output(k) => {
                 write(Opcode::Output);

--- a/zkvm/src/program.rs
+++ b/zkvm/src/program.rs
@@ -60,9 +60,7 @@ impl Program {
     def_op!(drop, Drop);
     def_op!(dup, Dup, usize);
     def_op!(eq, Eq);
-    def_op!(export, Export);
     def_op!(expr, Expr);
-    def_op!(import, Import);
     def_op!(input, Input);
     def_op!(issue, Issue);
     def_op!(log, Log);

--- a/zkvm/src/tx.rs
+++ b/zkvm/src/tx.rs
@@ -29,8 +29,6 @@ pub enum TxEntry {
     Input(ContractID),
     Output(Contract),
     Data(Vec<u8>),
-    Import, // TBD: parameters
-    Export, // TBD: parameters
 }
 
 /// Header metadata for the transaction
@@ -248,14 +246,6 @@ impl MerkleItem for TxEntry {
             }
             TxEntry::Data(data) => {
                 t.commit_bytes(b"data", data);
-            }
-            TxEntry::Import => {
-                // TBD: commit parameters
-                unimplemented!()
-            }
-            TxEntry::Export => {
-                // TBD: commit parameters
-                unimplemented!()
             }
         }
     }

--- a/zkvm/src/vm.rs
+++ b/zkvm/src/vm.rs
@@ -166,8 +166,6 @@ where
                 Instruction::Borrow => self.borrow()?,
                 Instruction::Retire => self.retire()?,
                 Instruction::Cloak(m, n) => self.cloak(m, n)?,
-                Instruction::Import => unimplemented!(),
-                Instruction::Export => unimplemented!(),
                 Instruction::Input => self.input()?,
                 Instruction::Output(k) => self.output(k)?,
                 Instruction::Contract(k) => self.contract(k)?,


### PR DESCRIPTION
We probably will use normal `issue`/`retire` instructions for pegging the external assets. If not, we could bring those back any time, but for now let's clean up the codebase from undesigned features.